### PR TITLE
feat: bookmarks, mock gate, OpenAI scorer, Vitest suite

### DIFF
--- a/app/alerts/page.tsx
+++ b/app/alerts/page.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { motion } from "framer-motion";
+import { Bell, FlaskConical, Star } from "lucide-react";
+import { toast } from "sonner";
+import { AlertRecord, BookmarkedListing, AIScoredListing } from "@/lib/types";
+import { ListingCard } from "@/components/dashboard/ListingCard";
+import { EmptyState } from "@/components/dashboard/EmptyState";
+import { MOCK_ALERTS } from "@/lib/mock-data";
+
+const MOCK_ENABLED = process.env.NEXT_PUBLIC_ENABLE_MOCK === "true";
+const MOCK_KEY = "hyh_mock_mode";
+const MOCK_BOOKMARKS_KEY = "hyh_bookmarks";
+
+function getMockBookmarks(): BookmarkedListing[] {
+  try {
+    const raw = localStorage.getItem(MOCK_BOOKMARKS_KEY);
+    return raw ? (JSON.parse(raw) as BookmarkedListing[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveMockBookmarks(bms: BookmarkedListing[]): void {
+  localStorage.setItem(MOCK_BOOKMARKS_KEY, JSON.stringify(bms));
+}
+
+function SkeletonCard() {
+  return (
+    <div
+      className="rounded-xl overflow-hidden animate-pulse"
+      style={{ background: "#161B22", border: "1px solid #21262D" }}
+    >
+      <div className="h-40" style={{ background: "#1C2430" }} />
+      <div className="p-4 space-y-3">
+        <div className="flex justify-between gap-2">
+          <div className="h-3.5 rounded w-3/4" style={{ background: "#1C2430" }} />
+          <div className="h-3.5 rounded w-1/5" style={{ background: "#1C2430" }} />
+        </div>
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-2.5 rounded" style={{ background: "#1C2430", width: `${[100, 80, 60][i - 1]}%` }} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function AlertsPage() {
+  const [alerts, setAlerts] = useState<AlertRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [mockMode, setMockMode] = useState(false);
+  const [bookmarks, setBookmarks] = useState<BookmarkedListing[]>([]);
+
+  useEffect(() => {
+    if (!MOCK_ENABLED) return;
+    setMockMode(localStorage.getItem(MOCK_KEY) === "true");
+  }, []);
+
+  const fetchAlerts = useCallback(async () => {
+    try {
+      const res = await fetch("/api/history");
+      const json = await res.json() as { success: boolean; data?: { alerts: AlertRecord[] } };
+      if (json.success && json.data) setAlerts(json.data.alerts);
+    } catch {
+      // fail silently
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchBookmarks = useCallback(async () => {
+    try {
+      const res = await fetch("/api/bookmarks");
+      const json = await res.json() as { success: boolean; data?: BookmarkedListing[] };
+      if (json.success && json.data) setBookmarks(json.data);
+    } catch {
+      // fail silently
+    }
+  }, []);
+
+  useEffect(() => {
+    if (MOCK_ENABLED && mockMode) {
+      setAlerts(MOCK_ALERTS);
+      setBookmarks(getMockBookmarks());
+      setLoading(false);
+    } else {
+      void fetchAlerts();
+      void fetchBookmarks();
+    }
+  }, [mockMode, fetchAlerts, fetchBookmarks]);
+
+  function handleToggleBookmark(listing: AIScoredListing) {
+    const exists = bookmarks.some((b) => b.listing.id === listing.id);
+
+    if (exists) {
+      const updated = bookmarks.filter((b) => b.listing.id !== listing.id);
+      setBookmarks(updated);
+      if (MOCK_ENABLED && mockMode) {
+        saveMockBookmarks(updated);
+      } else {
+        void fetch("/api/bookmarks", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ zpid: listing.id }),
+        });
+      }
+      toast("Home removed from bookmarks", { icon: <Star size={14} /> });
+    } else {
+      const newBm: BookmarkedListing = {
+        listing,
+        savedAt: new Date().toISOString(),
+        sold: false,
+      };
+      const updated = [...bookmarks, newBm];
+      setBookmarks(updated);
+      if (MOCK_ENABLED && mockMode) {
+        saveMockBookmarks(updated);
+      } else {
+        void fetch("/api/bookmarks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ listing }),
+        });
+      }
+      toast("Home saved ✦", {
+        icon: <Star size={14} fill="#39D353" stroke="#39D353" />,
+      });
+    }
+  }
+
+  const soldZpids = new Set(bookmarks.filter((b) => b.sold).map((b) => b.listing.id));
+  const bookmarkedZpids = new Set(bookmarks.map((b) => b.listing.id));
+
+  // Filter sold from display
+  const visibleAlerts = alerts.filter((a) => !soldZpids.has(a.listing.id));
+  const hotAlerts = visibleAlerts.filter((a) => a.listing.alertTier === "HOT");
+  const matchAlerts = visibleAlerts.filter((a) => a.listing.alertTier !== "HOT");
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      {/* Page header */}
+      <div
+        className="-mx-6 -mt-6 px-6 py-4 mb-6 flex items-center justify-between"
+        style={{ background: "#0D1117", borderBottom: "1px solid #21262D" }}
+      >
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <div className="w-1 h-5 rounded-full" style={{ background: "#39D353" }} />
+            <h1
+              className="text-2xl font-semibold"
+              style={{ fontFamily: "var(--font-space-grotesk, sans-serif)", color: "#E6EDF3" }}
+            >
+              Alert History
+            </h1>
+          </div>
+          {visibleAlerts.length > 0 && (
+            <span
+              className="px-2 py-0.5 rounded-full text-xs font-medium"
+              style={{
+                background: "#161B22",
+                border: "1px solid #21262D",
+                color: "#8B949E",
+                fontFamily: "var(--font-inter, sans-serif)",
+              }}
+            >
+              {visibleAlerts.length} total
+            </span>
+          )}
+        </div>
+
+        {MOCK_ENABLED && mockMode && (
+          <div
+            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs"
+            style={{
+              background: "rgba(57,211,83,0.06)",
+              border: "1px solid rgba(57,211,83,0.2)",
+              color: "#39D353",
+              fontFamily: "var(--font-inter, sans-serif)",
+            }}
+          >
+            <FlaskConical size={12} />
+            Mock mode
+          </div>
+        )}
+      </div>
+
+      {/* Content */}
+      {loading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[1, 2, 3, 4, 5, 6].map((i) => <SkeletonCard key={i} />)}
+        </div>
+      ) : visibleAlerts.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className="space-y-8">
+          {/* HOT alerts */}
+          {hotAlerts.length > 0 && (
+            <section>
+              <div className="flex items-center gap-2 mb-4">
+                <span
+                  className="px-2 py-0.5 rounded-full text-[10px] font-bold tracking-wider"
+                  style={{
+                    background: "rgba(255,107,53,0.1)",
+                    border: "1px solid rgba(255,107,53,0.2)",
+                    color: "#FF6B35",
+                    fontFamily: "var(--font-inter, sans-serif)",
+                  }}
+                >
+                  🔥 HOT
+                </span>
+                <span
+                  className="text-xs"
+                  style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}
+                >
+                  {hotAlerts.length} listing{hotAlerts.length !== 1 ? "s" : ""}
+                </span>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {hotAlerts.map((record, i) => (
+                  <motion.div
+                    key={record.id}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.2, delay: i * 0.05 }}
+                  >
+                    <ListingCard
+                      record={record}
+                      index={i}
+                      isBookmarked={bookmarkedZpids.has(record.listing.id)}
+                      onToggleBookmark={handleToggleBookmark}
+                    />
+                  </motion.div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* MATCH alerts */}
+          {matchAlerts.length > 0 && (
+            <section>
+              <div className="flex items-center gap-2 mb-4">
+                <span
+                  className="px-2 py-0.5 rounded-full text-[10px] font-bold tracking-wider"
+                  style={{
+                    background: "rgba(88,166,255,0.1)",
+                    border: "1px solid rgba(88,166,255,0.2)",
+                    color: "#58A6FF",
+                    fontFamily: "var(--font-inter, sans-serif)",
+                  }}
+                >
+                  ✦ MATCH
+                </span>
+                <span
+                  className="text-xs"
+                  style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}
+                >
+                  {matchAlerts.length} listing{matchAlerts.length !== 1 ? "s" : ""}
+                </span>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {matchAlerts.map((record, i) => (
+                  <motion.div
+                    key={record.id}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.2, delay: i * 0.05 }}
+                  >
+                    <ListingCard
+                      record={record}
+                      index={i}
+                      isBookmarked={bookmarkedZpids.has(record.listing.id)}
+                      onToggleBookmark={handleToggleBookmark}
+                    />
+                  </motion.div>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest } from "next/server";
+import { getBookmarks, addBookmark, removeBookmark } from "@/lib/storage";
+import { AIScoredListing } from "@/lib/types";
+
+export async function GET() {
+  try {
+    const bookmarks = await getBookmarks();
+    return Response.json({ success: true, data: bookmarks });
+  } catch (err) {
+    return Response.json({ success: false, error: String(err) }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as { listing: AIScoredListing };
+    await addBookmark(body.listing);
+    return Response.json({ success: true });
+  } catch (err) {
+    return Response.json({ success: false, error: String(err) }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const body = (await request.json()) as { zpid: string };
+    await removeBookmark(body.zpid);
+    return Response.json({ success: true });
+  } catch (err) {
+    return Response.json({ success: false, error: String(err) }, { status: 500 });
+  }
+}

--- a/app/api/scrape/route.ts
+++ b/app/api/scrape/route.ts
@@ -10,6 +10,8 @@ import {
   addSeenIds,
   pushAlertRecord,
   pushScanRecord,
+  getBookmarkIds,
+  markBookmarkSold,
 } from "@/lib/storage";
 import { AlertRecord, ScanRecord } from "@/lib/types";
 
@@ -50,15 +52,28 @@ export async function POST(request: NextRequest) {
     const allListings = await runZillowScraper(prefs.searchArea);
     listingsFound = allListings.length;
 
-    // 3. Deduplicate
+    // 3. Check bookmarked listings for sold status
+    const bookmarkIds = await getBookmarkIds();
+    if (bookmarkIds.size > 0) {
+      const activeForSaleIds = new Set(
+        allListings.filter((l) => l.listingType === "FOR_SALE").map((l) => l.id)
+      );
+      for (const zpid of bookmarkIds) {
+        if (!activeForSaleIds.has(zpid)) {
+          await markBookmarkSold(zpid);
+        }
+      }
+    }
+
+    // 4. Deduplicate
     const seenIds = await getSeenIds();
     const unseen = allListings.filter((l) => !seenIds.has(l.id));
     newListings = unseen.length;
 
-    // 4. Hard filters (FOR_SALE, price, beds, baths, sqft, yearBuilt, hoa)
+    // 5. Hard filters (FOR_SALE, price, beds, baths, sqft, yearBuilt, hoa)
     const filtered = unseen.filter((l) => matchesHardFilters(l, prefs));
 
-    // 5. Mark ALL new listings as seen (even unmatched)
+    // 6. Mark ALL new listings as seen (even unmatched)
     if (unseen.length > 0) {
       await addSeenIds(unseen.map((l) => l.id));
     }

--- a/app/bookmarks/page.tsx
+++ b/app/bookmarks/page.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { motion } from "framer-motion";
+import { Bookmark, FlaskConical, Star } from "lucide-react";
+import { toast } from "sonner";
+import { BookmarkedListing, AIScoredListing } from "@/lib/types";
+import { ListingCard } from "@/components/dashboard/ListingCard";
+import { MOCK_ALERTS } from "@/lib/mock-data";
+
+const MOCK_ENABLED = process.env.NEXT_PUBLIC_ENABLE_MOCK === "true";
+const MOCK_KEY = "hyh_mock_mode";
+const MOCK_BOOKMARKS_KEY = "hyh_bookmarks";
+
+function getMockBookmarks(): BookmarkedListing[] {
+  try {
+    const raw = localStorage.getItem(MOCK_BOOKMARKS_KEY);
+    return raw ? (JSON.parse(raw) as BookmarkedListing[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveMockBookmarks(bms: BookmarkedListing[]): void {
+  localStorage.setItem(MOCK_BOOKMARKS_KEY, JSON.stringify(bms));
+}
+
+function SkeletonCard() {
+  return (
+    <div
+      className="rounded-xl overflow-hidden animate-pulse"
+      style={{ background: "#161B22", border: "1px solid #21262D" }}
+    >
+      <div className="h-40" style={{ background: "#1C2430" }} />
+      <div className="p-4 space-y-3">
+        <div className="flex justify-between gap-2">
+          <div className="h-3.5 rounded w-3/4" style={{ background: "#1C2430" }} />
+          <div className="h-3.5 rounded w-1/5" style={{ background: "#1C2430" }} />
+        </div>
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-2.5 rounded"
+            style={{ background: "#1C2430", width: `${[100, 80, 60][i - 1]}%` }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function BookmarksPage() {
+  const [bookmarks, setBookmarks] = useState<BookmarkedListing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [mockMode, setMockMode] = useState(false);
+
+  useEffect(() => {
+    if (!MOCK_ENABLED) return;
+    setMockMode(localStorage.getItem(MOCK_KEY) === "true");
+  }, []);
+
+  const fetchBookmarks = useCallback(async () => {
+    try {
+      const res = await fetch("/api/bookmarks");
+      const json = (await res.json()) as {
+        success: boolean;
+        data?: BookmarkedListing[];
+      };
+      if (json.success && json.data) setBookmarks(json.data);
+    } catch {
+      // fail silently
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (MOCK_ENABLED && mockMode) {
+      setBookmarks(getMockBookmarks());
+      setLoading(false);
+    } else {
+      void fetchBookmarks();
+    }
+  }, [mockMode, fetchBookmarks]);
+
+  function handleToggleBookmark(listing: AIScoredListing) {
+    const exists = bookmarks.some((b) => b.listing.id === listing.id);
+
+    if (exists) {
+      // Remove
+      const updated = bookmarks.filter((b) => b.listing.id !== listing.id);
+      setBookmarks(updated);
+      if (MOCK_ENABLED && mockMode) {
+        saveMockBookmarks(updated);
+      } else {
+        void fetch("/api/bookmarks", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ zpid: listing.id }),
+        });
+      }
+      toast("Home removed from bookmarks", {
+        icon: <Star size={14} />,
+      });
+    } else {
+      // Add
+      const newBm: BookmarkedListing = {
+        listing,
+        savedAt: new Date().toISOString(),
+        sold: false,
+      };
+      const updated = [...bookmarks, newBm];
+      setBookmarks(updated);
+      if (MOCK_ENABLED && mockMode) {
+        saveMockBookmarks(updated);
+      } else {
+        void fetch("/api/bookmarks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ listing }),
+        });
+      }
+      toast("Home saved ✦", {
+        icon: <Star size={14} fill="#39D353" stroke="#39D353" />,
+      });
+    }
+  }
+
+  const bookmarkedZpids = new Set(bookmarks.map((b) => b.listing.id));
+  const activeBookmarks = bookmarks.filter((b) => !b.sold);
+  const soldBookmarks = bookmarks.filter((b) => b.sold);
+
+  // Convert BookmarkedListing → AlertRecord shape for ListingCard
+  function toAlertRecord(bm: BookmarkedListing) {
+    return {
+      id: bm.listing.id,
+      listing: bm.listing,
+      sentAt: bm.savedAt,
+      emailDelivered: false,
+    };
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      {/* Page header */}
+      <div
+        className="-mx-6 -mt-6 px-6 py-4 mb-6 flex items-center justify-between"
+        style={{ background: "#0D1117", borderBottom: "1px solid #21262D" }}
+      >
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <div className="w-1 h-5 rounded-full" style={{ background: "#39D353" }} />
+            <h1
+              className="text-2xl font-semibold"
+              style={{
+                fontFamily: "var(--font-space-grotesk, sans-serif)",
+                color: "#E6EDF3",
+              }}
+            >
+              Bookmarks
+            </h1>
+          </div>
+          {bookmarks.length > 0 && (
+            <span
+              className="px-2 py-0.5 rounded-full text-xs font-medium"
+              style={{
+                background: "#161B22",
+                border: "1px solid #21262D",
+                color: "#8B949E",
+                fontFamily: "var(--font-inter, sans-serif)",
+              }}
+            >
+              {bookmarks.length} saved
+            </span>
+          )}
+        </div>
+
+        {MOCK_ENABLED && mockMode && (
+          <div
+            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs"
+            style={{
+              background: "rgba(57,211,83,0.06)",
+              border: "1px solid rgba(57,211,83,0.2)",
+              color: "#39D353",
+              fontFamily: "var(--font-inter, sans-serif)",
+            }}
+          >
+            <FlaskConical size={12} />
+            Mock mode
+          </div>
+        )}
+      </div>
+
+      {/* Content */}
+      {loading ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[1, 2, 3].map((i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </div>
+      ) : bookmarks.length === 0 ? (
+        <div className="flex flex-col items-center justify-center min-h-[300px]">
+          <Bookmark size={32} style={{ color: "#30363D" }} className="mb-4" />
+          <p
+            className="text-base font-semibold mb-1"
+            style={{
+              color: "#E6EDF3",
+              fontFamily: "var(--font-space-grotesk, sans-serif)",
+            }}
+          >
+            No bookmarks yet.
+          </p>
+          <p
+            className="text-sm"
+            style={{
+              color: "#8B949E",
+              fontFamily: "var(--font-inter, sans-serif)",
+            }}
+          >
+            Star a listing to save it here for quick viewing.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {/* Active bookmarks */}
+          {activeBookmarks.length > 0 && (
+            <section>
+              {soldBookmarks.length > 0 && (
+                <div className="flex items-center gap-2 mb-4">
+                  <span
+                    className="px-2 py-0.5 rounded-full text-[10px] font-bold tracking-wider"
+                    style={{
+                      background: "rgba(57,211,83,0.1)",
+                      border: "1px solid rgba(57,211,83,0.2)",
+                      color: "#39D353",
+                      fontFamily: "var(--font-inter, sans-serif)",
+                    }}
+                  >
+                    ✦ ACTIVE
+                  </span>
+                  <span
+                    className="text-xs"
+                    style={{
+                      color: "#484F58",
+                      fontFamily: "var(--font-inter, sans-serif)",
+                    }}
+                  >
+                    {activeBookmarks.length} listing{activeBookmarks.length !== 1 ? "s" : ""}
+                  </span>
+                </div>
+              )}
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {activeBookmarks.map((bm, i) => (
+                  <motion.div
+                    key={bm.listing.id}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.2, delay: i * 0.05 }}
+                  >
+                    <ListingCard
+                      record={toAlertRecord(bm)}
+                      index={i}
+                      isBookmarked={bookmarkedZpids.has(bm.listing.id)}
+                      onToggleBookmark={handleToggleBookmark}
+                    />
+                  </motion.div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Sold bookmarks */}
+          {soldBookmarks.length > 0 && (
+            <section>
+              <div className="flex items-center gap-2 mb-4">
+                <span
+                  className="px-2 py-0.5 rounded-full text-[10px] font-bold tracking-wider"
+                  style={{
+                    background: "rgba(180,28,28,0.1)",
+                    border: "1px solid rgba(180,28,28,0.25)",
+                    color: "#F87171",
+                    fontFamily: "var(--font-inter, sans-serif)",
+                  }}
+                >
+                  SOLD
+                </span>
+                <span
+                  className="text-xs"
+                  style={{
+                    color: "#484F58",
+                    fontFamily: "var(--font-inter, sans-serif)",
+                  }}
+                >
+                  {soldBookmarks.length} listing{soldBookmarks.length !== 1 ? "s" : ""} no longer available
+                </span>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {soldBookmarks.map((bm, i) => (
+                  <motion.div
+                    key={bm.listing.id}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.2, delay: i * 0.05 }}
+                  >
+                    <ListingCard
+                      record={toAlertRecord(bm)}
+                      index={i}
+                      isBookmarked={bookmarkedZpids.has(bm.listing.id)}
+                      onToggleBookmark={handleToggleBookmark}
+                      showSoldBanner
+                    />
+                  </motion.div>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      )}
+
+      {/* Mock hint */}
+      {MOCK_ENABLED && mockMode && bookmarks.length === 0 && (
+        <div
+          className="mt-8 rounded-xl p-4 text-center text-xs"
+          style={{
+            background: "rgba(57,211,83,0.04)",
+            border: "1px dashed rgba(57,211,83,0.2)",
+            color: "#484F58",
+            fontFamily: "var(--font-inter, sans-serif)",
+          }}
+        >
+          In mock mode — star any listing on the Dashboard or Alerts page to save it here.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,67 +4,67 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* ─── Design tokens ─────────────────────────────────────── */
 @theme {
-  /* Onyx palette */
-  --color-onyx-50: #f5f5f5;
-  --color-onyx-100: #e8e8e8;
-  --color-onyx-200: #d0d0d0;
-  --color-onyx-300: #b8b8b8;
-  --color-onyx-400: #a0a0a0;
-  --color-onyx-500: #888888;
-  --color-onyx-600: #606060;
-  --color-onyx-700: #404040;
-  --color-onyx-800: #282828;
-  --color-onyx-900: #181818;
-  --color-onyx-950: #0f0f0f;
-  --color-onyx: #1a1a1a;
+  --color-bg-base:     #080C10;
+  --color-bg-surface:  #0D1117;
+  --color-bg-elevated: #161B22;
+  --color-bg-hover:    #1C2430;
 
-  /* Brand orange */
-  --color-brand: #f97316;
-  --color-brand-light: #fb923c;
-  --color-brand-dark: #ea6c00;
+  --color-border-subtle: #21262D;
+  --color-border-strong: #30363D;
 
-  /* Font */
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --color-content-primary:   #E6EDF3;
+  --color-content-secondary: #8B949E;
+  --color-content-muted:     #484F58;
+
+  --color-accent:     #39D353;
+  --color-accent-dim: #1A7F37;
+
+  --color-hot:   #FF6B35;
+  --color-match: #58A6FF;
+
+  --font-sans:    "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-display: "Space Grotesk", "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+  --font-price:   "Object Sans", "Space Grotesk", "Inter", sans-serif;
 }
 
-* {
-  box-sizing: border-box;
-}
+/* ─── Base ───────────────────────────────────────────────── */
+* { box-sizing: border-box; }
 
-html {
-  scroll-behavior: smooth;
-}
+html { scroll-behavior: smooth; }
 
 body {
   font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: #080C10;
+  color: #E6EDF3;
 }
 
-/* Scrollbar styling */
-::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-::-webkit-scrollbar-track {
-  background: #18181b;
-}
-::-webkit-scrollbar-thumb {
-  background: #3f3f46;
-  border-radius: 3px;
-}
-::-webkit-scrollbar-thumb:hover {
-  background: #52525b;
+/* ─── Global scrollbar ───────────────────────────────────── */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: #30363D; border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: #484F58; }
+
+/* ─── Custom scrollbar (narrow, for panels) ──────────────── */
+.custom-scrollbar::-webkit-scrollbar { width: 4px; }
+.custom-scrollbar::-webkit-scrollbar-track { background: transparent; }
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #30363D;
+  border-radius: 2px;
 }
 
-/* Focus ring */
+/* ─── Focus ring ─────────────────────────────────────────── */
 :focus-visible {
-  outline: 2px solid #f97316;
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(57, 211, 83, 0.4);
+  border-radius: 6px;
 }
 
-/* Range input styling */
+/* ─── Range slider — remove browser default ─────────────── */
 input[type="range"] {
   -webkit-appearance: none;
   appearance: none;
@@ -72,42 +72,112 @@ input[type="range"] {
   cursor: pointer;
   width: 100%;
 }
-input[type="range"]::-webkit-slider-track {
-  background: #3f3f46;
+
+/* ─── Custom slider class ────────────────────────────────── */
+.custom-slider {
+  -webkit-appearance: none;
+  appearance: none;
   height: 4px;
   border-radius: 2px;
+  background: #21262D;
+  outline: none;
+  cursor: pointer;
+  width: 100%;
 }
-input[type="range"]::-webkit-slider-thumb {
+
+.custom-slider::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 2px;
+  background: #21262D;
+}
+
+.custom-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
   width: 16px;
   height: 16px;
-  background: #f97316;
   border-radius: 50%;
-  margin-top: -6px;
+  background: #E6EDF3;
+  border: 2px solid #39D353;
   cursor: pointer;
-  transition: background 0.15s;
+  transition: box-shadow 150ms ease, transform 150ms ease;
+  margin-top: -6px;
 }
-input[type="range"]::-webkit-slider-thumb:hover {
-  background: #fb923c;
+
+.custom-slider::-webkit-slider-thumb:hover {
+  box-shadow: 0 0 0 4px rgba(57, 211, 83, 0.2);
+  transform: scale(1.1);
 }
-input[type="range"]::-moz-range-track {
-  background: #3f3f46;
+
+.custom-slider::-moz-range-track {
   height: 4px;
   border-radius: 2px;
+  background: #21262D;
 }
-input[type="range"]::-moz-range-thumb {
+
+.custom-slider::-moz-range-thumb {
   width: 16px;
   height: 16px;
-  background: #f97316;
   border-radius: 50%;
-  border: none;
+  background: #E6EDF3;
+  border: 2px solid #39D353;
   cursor: pointer;
 }
 
+/* ─── Scan Now button ────────────────────────────────────── */
+.btn-scan {
+  background: #39D353;
+  color: #080C10;
+  font-weight: 600;
+  font-size: 0.875rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: none;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.btn-scan:hover {
+  background: #45e863;
+  box-shadow: 0 0 20px rgba(57, 211, 83, 0.4);
+}
+
+.btn-scan:active {
+  transform: scale(0.97);
+}
+
+.btn-scan:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+  border: 1px dashed #484F58;
+}
+
+/* ─── Alert grid: center orphaned last card ──────────────── */
+.alert-grid > *:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: center;
+}
+.alert-grid > *:last-child:nth-child(odd) > * {
+  width: 100%;
+  max-width: 320px;
+}
+
+/* ─── Cursor blink for terminal ──────────────────────────── */
+@keyframes cursor-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
+/* ─── Shadcn/tailwind overrides ──────────────────────────── */
 @theme inline {
-  --font-heading: var(--font-sans);
   --font-sans: var(--font-sans);
+  --font-display: var(--font-display);
+  --font-mono: var(--font-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -116,11 +186,6 @@ input[type="range"]::-moz-range-thumb {
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -144,87 +209,39 @@ input[type="range"]::-moz-range-thumb {
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) * 1.4);
   --radius-2xl: calc(var(--radius) * 1.8);
-  --radius-3xl: calc(var(--radius) * 2.2);
-  --radius-4xl: calc(var(--radius) * 2.6);
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
+  --background: #080C10;
+  --foreground: #E6EDF3;
+  --card: #161B22;
+  --card-foreground: #E6EDF3;
+  --popover: #161B22;
+  --popover-foreground: #E6EDF3;
+  --primary: #39D353;
+  --primary-foreground: #080C10;
+  --secondary: #21262D;
+  --secondary-foreground: #E6EDF3;
+  --muted: #21262D;
+  --muted-foreground: #8B949E;
+  --accent: #39D353;
+  --accent-foreground: #080C10;
+  --destructive: #FF6B35;
+  --border: #21262D;
+  --input: #21262D;
+  --ring: #39D353;
   --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-}
-
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar: #0D1117;
+  --sidebar-foreground: #E6EDF3;
+  --sidebar-primary: #39D353;
+  --sidebar-primary-foreground: #080C10;
+  --sidebar-accent: #1C2430;
+  --sidebar-accent-foreground: #E6EDF3;
+  --sidebar-border: #21262D;
+  --sidebar-ring: #39D353;
 }
 
 @layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
-  html {
-    @apply font-sans;
-  }
+  * { @apply border-border; }
+  body { @apply bg-bg-base text-content-primary; }
 }

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { motion } from "framer-motion";
+import { Activity, FlaskConical, CheckCircle2, XCircle, Clock } from "lucide-react";
+import { formatDistanceToNow, format } from "date-fns";
+import { ScanRecord } from "@/lib/types";
+import { MOCK_SCAN_HISTORY } from "@/lib/mock-data";
+
+const MOCK_ENABLED = process.env.NEXT_PUBLIC_ENABLE_MOCK === "true";
+const MOCK_KEY = "hyh_mock_mode";
+
+function StatPill({
+  value,
+  label,
+  accent,
+}: {
+  value: number;
+  label: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <span
+        className="font-bold text-lg leading-none"
+        style={{
+          color: accent && value > 0 ? "#39D353" : "#E6EDF3",
+          fontFamily: "var(--font-space-grotesk, sans-serif)",
+        }}
+      >
+        {value}
+      </span>
+      <span
+        className="text-[10px] uppercase tracking-widest"
+        style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function ScanRow({ scan, index }: { scan: ScanRecord; index: number }) {
+  const hasMatches = scan.matchedListings > 0;
+  const timeAgo = formatDistanceToNow(new Date(scan.runAt), { addSuffix: true });
+  const timeExact = format(new Date(scan.runAt), "MMM d, h:mm a");
+  const durationSec = (scan.durationMs / 1000).toFixed(1);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, delay: index * 0.04 }}
+      className="flex items-center gap-4 rounded-xl px-5 py-4"
+      style={{
+        background: "#161B22",
+        border: `1px solid ${hasMatches ? "rgba(57,211,83,0.2)" : "#21262D"}`,
+        borderTop: hasMatches ? "2px solid #39D353" : "2px solid #21262D",
+      }}
+    >
+      {/* Status icon */}
+      <div className="shrink-0">
+        {hasMatches ? (
+          <CheckCircle2 size={18} style={{ color: "#39D353" }} />
+        ) : (
+          <XCircle size={16} style={{ color: "#484F58" }} />
+        )}
+      </div>
+
+      {/* Time */}
+      <div className="min-w-[140px]">
+        <div
+          className="text-sm font-medium"
+          style={{ color: "#E6EDF3", fontFamily: "var(--font-inter, sans-serif)" }}
+        >
+          {timeAgo}
+        </div>
+        <div
+          className="text-xs mt-0.5"
+          style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}
+        >
+          {timeExact}
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div
+        className="flex items-center gap-6 flex-1"
+        style={{ borderLeft: "1px solid #21262D", paddingLeft: 24 }}
+      >
+        <StatPill value={scan.listingsFound} label="Found" />
+        <StatPill value={scan.newListings} label="New" accent />
+        <StatPill value={scan.matchedListings} label="Matched" accent />
+        <StatPill value={scan.alertsSent} label="Alerted" accent />
+      </div>
+
+      {/* Duration */}
+      <div
+        className="shrink-0 flex items-center gap-1 text-xs"
+        style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}
+      >
+        <Clock size={11} />
+        {durationSec}s
+      </div>
+    </motion.div>
+  );
+}
+
+export default function HistoryPage() {
+  const [scans, setScans] = useState<ScanRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [mockMode, setMockMode] = useState(false);
+
+  useEffect(() => {
+    if (!MOCK_ENABLED) return;
+    setMockMode(localStorage.getItem(MOCK_KEY) === "true");
+  }, []);
+
+  const fetchHistory = useCallback(async () => {
+    try {
+      const res = await fetch("/api/history");
+      const json = await res.json() as { success: boolean; data?: { scans: ScanRecord[] } };
+      if (json.success && json.data) setScans(json.data.scans);
+    } catch {
+      // fail silently
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (MOCK_ENABLED && mockMode) {
+      setScans(MOCK_SCAN_HISTORY);
+      setLoading(false);
+    } else {
+      void fetchHistory();
+    }
+  }, [mockMode, fetchHistory]);
+
+  // Aggregate stats
+  const totalFound    = scans.reduce((s, r) => s + r.listingsFound, 0);
+  const totalNew      = scans.reduce((s, r) => s + r.newListings, 0);
+  const totalMatched  = scans.reduce((s, r) => s + r.matchedListings, 0);
+  const totalAlerted  = scans.reduce((s, r) => s + r.alertsSent, 0);
+  const avgDurationMs = scans.length
+    ? Math.round(scans.reduce((s, r) => s + r.durationMs, 0) / scans.length)
+    : 0;
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      {/* Page header */}
+      <div
+        className="-mx-6 -mt-6 px-6 py-4 mb-6 flex items-center justify-between"
+        style={{ background: "#0D1117", borderBottom: "1px solid #21262D" }}
+      >
+        <div className="flex items-center gap-2">
+          <div className="w-1 h-5 rounded-full" style={{ background: "#39D353" }} />
+          <h1
+            className="text-2xl font-semibold"
+            style={{ fontFamily: "var(--font-space-grotesk, sans-serif)", color: "#E6EDF3" }}
+          >
+            Scan History
+          </h1>
+        </div>
+
+        {MOCK_ENABLED && mockMode && (
+          <div
+            className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs"
+            style={{
+              background: "rgba(57,211,83,0.06)",
+              border: "1px solid rgba(57,211,83,0.2)",
+              color: "#39D353",
+              fontFamily: "var(--font-inter, sans-serif)",
+            }}
+          >
+            <FlaskConical size={12} />
+            Mock mode
+          </div>
+        )}
+      </div>
+
+      {/* Summary cards */}
+      {!loading && scans.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-6">
+          {[
+            { label: "Total Scans",      value: scans.length,    accent: false },
+            { label: "Listings Checked", value: totalFound,      accent: false },
+            { label: "New Seen",         value: totalNew,        accent: true  },
+            { label: "Matched",          value: totalMatched,    accent: true  },
+            { label: "Alerts Sent",      value: totalAlerted,    accent: true  },
+          ].map(({ label, value, accent }, i) => (
+            <motion.div
+              key={label}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.2, delay: i * 0.05 }}
+              className="rounded-xl px-4 py-3 flex flex-col gap-1"
+              style={{
+                background: "#161B22",
+                border: `1px solid #21262D`,
+                borderTop: accent && value > 0 ? "2px solid #39D353" : "2px solid #21262D",
+              }}
+            >
+              <span
+                className="text-2xl font-bold"
+                style={{
+                  color: accent && value > 0 ? "#39D353" : "#E6EDF3",
+                  fontFamily: "var(--font-space-grotesk, sans-serif)",
+                }}
+              >
+                {value}
+              </span>
+              <span
+                className="text-[10px] uppercase tracking-widest"
+                style={{ color: "#8B949E", fontFamily: "var(--font-inter, sans-serif)" }}
+              >
+                {label}
+              </span>
+            </motion.div>
+          ))}
+        </div>
+      )}
+
+      {/* Avg duration note */}
+      {!loading && scans.length > 0 && (
+        <div
+          className="flex items-center gap-1.5 mb-4 text-xs"
+          style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}
+        >
+          <Activity size={11} />
+          {scans.length} scans — avg {(avgDurationMs / 1000).toFixed(1)}s per run
+        </div>
+      )}
+
+      {/* Scan list */}
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3, 4].map((i) => (
+            <div
+              key={i}
+              className="h-20 rounded-xl animate-pulse"
+              style={{ background: "#161B22", border: "1px solid #21262D" }}
+            />
+          ))}
+        </div>
+      ) : scans.length === 0 ? (
+        <div className="flex flex-col items-center justify-center min-h-[300px]">
+          <Activity size={32} style={{ color: "#30363D" }} className="mb-4" />
+          <p
+            className="text-base font-semibold mb-1"
+            style={{ color: "#E6EDF3", fontFamily: "var(--font-space-grotesk, sans-serif)" }}
+          >
+            No scans yet.
+          </p>
+          <p
+            className="text-sm"
+            style={{ color: "#8B949E", fontFamily: "var(--font-inter, sans-serif)" }}
+          >
+            Scans run automatically 4× daily. History will appear here.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {scans.map((scan, i) => (
+            <ScanRow key={scan.id} scan={scan} index={i} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,21 @@
 import type { Metadata } from "next";
-import { Inter, Geist } from "next/font/google";
+import { Inter, Space_Grotesk } from "next/font/google";
 import "./globals.css";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
 import { Toaster } from "sonner";
-import { cn } from "@/lib/utils";
-
-const geist = Geist({subsets:['latin'],variable:'--font-sans'});
 
 const inter = Inter({
   subsets: ["latin"],
   display: "swap",
+  variable: "--font-inter",
+});
+
+const spaceGrotesk = Space_Grotesk({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-space-grotesk",
+  weight: ["400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -26,15 +31,30 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={cn("h-full", inter.className, "font-sans", geist.variable)}>
-      <body className="min-h-full bg-[#0f0f0f] text-zinc-100 antialiased">
+    <html
+      lang="en"
+      className={`h-full ${inter.variable} ${spaceGrotesk.variable}`}
+    >
+      <body
+        className="min-h-full antialiased"
+        style={{ background: "#080C10", color: "#E6EDF3", fontFamily: "var(--font-inter, Inter, sans-serif)" }}
+      >
         <Sidebar />
-        <div className="lg:ml-56 flex flex-col min-h-screen">
+        <div className="lg:ml-[220px] flex flex-col min-h-screen">
           <Header />
-          <main className="flex-1 p-4 lg:p-6">{children}</main>
-          <footer className="px-4 py-3 border-t border-zinc-800 text-center">
-            <span className="text-xs text-zinc-600">
-              Powered by HuntYourHome
+          <main className="flex-1 px-6 py-6">{children}</main>
+          <footer
+            className="text-center mt-8 py-8"
+            style={{ borderTop: "1px solid #21262D" }}
+          >
+            <span
+              className="text-xs"
+              style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}
+            >
+              Powered by{" "}
+              <span style={{ color: "#39D353", fontWeight: 500 }}>
+                HuntYourHome
+              </span>
             </span>
           </footer>
         </div>
@@ -43,9 +63,10 @@ export default function RootLayout({
           position="bottom-right"
           toastOptions={{
             style: {
-              background: "#18181b",
-              border: "1px solid #27272a",
-              color: "#f4f4f5",
+              background: "#161B22",
+              border: "1px solid #21262D",
+              color: "#E6EDF3",
+              fontFamily: "var(--font-inter, Inter, sans-serif)",
             },
           }}
         />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { toast } from "sonner";
+import { Star } from "lucide-react";
 import { StatsBar } from "@/components/dashboard/StatsBar";
 import { AlertFeed } from "@/components/dashboard/AlertFeed";
 import { FilterPanel } from "@/components/filters/FilterPanel";
-import { AlertRecord, ScanRecord, UserPreferences } from "@/lib/types";
+import { AlertRecord, ScanRecord, UserPreferences, BookmarkedListing, AIScoredListing } from "@/lib/types";
+import { MOCK_ALERTS, MOCK_STATS } from "@/lib/mock-data";
 
 interface HistoryData {
   alerts: AlertRecord[];
@@ -21,11 +24,46 @@ interface PrefsData {
   data: UserPreferences;
 }
 
+const MOCK_ENABLED = process.env.NEXT_PUBLIC_ENABLE_MOCK === "true";
+const MOCK_STORAGE_KEY = "hyh_mock_mode";
+const MOCK_BOOKMARKS_KEY = "hyh_bookmarks";
+
+function getMockBookmarks(): BookmarkedListing[] {
+  try {
+    const raw = localStorage.getItem(MOCK_BOOKMARKS_KEY);
+    return raw ? (JSON.parse(raw) as BookmarkedListing[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveMockBookmarks(bms: BookmarkedListing[]): void {
+  localStorage.setItem(MOCK_BOOKMARKS_KEY, JSON.stringify(bms));
+}
+
 export default function HomePage() {
   const [historyData, setHistoryData] = useState<HistoryData | null>(null);
   const [prefs, setPrefs] = useState<UserPreferences | null>(null);
   const [loadingHistory, setLoadingHistory] = useState(true);
   const [loadingPrefs, setLoadingPrefs] = useState(true);
+  const [mockMode, setMockMode] = useState(false);
+  const [bookmarks, setBookmarks] = useState<BookmarkedListing[]>([]);
+
+  // Persist mock mode to localStorage — only in dev
+  useEffect(() => {
+    if (!MOCK_ENABLED) return;
+    const stored = localStorage.getItem(MOCK_STORAGE_KEY);
+    if (stored === "true") setMockMode(true);
+  }, []);
+
+  function toggleMockMode() {
+    if (!MOCK_ENABLED) return;
+    setMockMode((prev) => {
+      const next = !prev;
+      localStorage.setItem(MOCK_STORAGE_KEY, String(next));
+      return next;
+    });
+  }
 
   const fetchHistory = useCallback(async () => {
     try {
@@ -51,49 +89,131 @@ export default function HomePage() {
     }
   }, []);
 
+  const fetchBookmarks = useCallback(async () => {
+    try {
+      const res = await fetch("/api/bookmarks");
+      const json = await res.json() as { success: boolean; data?: BookmarkedListing[] };
+      if (json.success && json.data) setBookmarks(json.data);
+    } catch {
+      // fail silently
+    }
+  }, []);
+
   useEffect(() => {
     void fetchHistory();
     void fetchPrefs();
   }, [fetchHistory, fetchPrefs]);
 
-  const stats = historyData?.stats ?? {
-    todayScans: 0,
-    seenCount: 0,
-    lastScan: null,
-    totalAlerts: 0,
-    recentMatches: 0,
-  };
+  // Load bookmarks whenever mock mode resolves
+  useEffect(() => {
+    if (MOCK_ENABLED && mockMode) {
+      setBookmarks(getMockBookmarks());
+    } else {
+      void fetchBookmarks();
+    }
+  }, [mockMode, fetchBookmarks]);
+
+  function handleToggleBookmark(listing: AIScoredListing) {
+    const exists = bookmarks.some((b) => b.listing.id === listing.id);
+
+    if (exists) {
+      const updated = bookmarks.filter((b) => b.listing.id !== listing.id);
+      setBookmarks(updated);
+      if (MOCK_ENABLED && mockMode) {
+        saveMockBookmarks(updated);
+      } else {
+        void fetch("/api/bookmarks", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ zpid: listing.id }),
+        });
+      }
+      toast("Home removed from bookmarks", { icon: <Star size={14} /> });
+    } else {
+      const newBm: BookmarkedListing = {
+        listing,
+        savedAt: new Date().toISOString(),
+        sold: false,
+      };
+      const updated = [...bookmarks, newBm];
+      setBookmarks(updated);
+      if (MOCK_ENABLED && mockMode) {
+        saveMockBookmarks(updated);
+      } else {
+        void fetch("/api/bookmarks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ listing }),
+        });
+      }
+      toast("Home saved ✦", {
+        icon: <Star size={14} fill="#39D353" stroke="#39D353" />,
+      });
+    }
+  }
+
+  // Compute sold zpids to filter from feed
+  const soldZpids = new Set(
+    bookmarks.filter((b) => b.sold).map((b) => b.listing.id)
+  );
+  const bookmarkedZpids = new Set(bookmarks.map((b) => b.listing.id));
+
+  const rawAlerts: AlertRecord[] = (MOCK_ENABLED && mockMode)
+    ? MOCK_ALERTS
+    : (historyData?.alerts ?? []);
+
+  // Filter out sold listings from the main feed
+  const displayAlerts = rawAlerts.filter((r) => !soldZpids.has(r.listing.id));
+
+  const displayStats = (MOCK_ENABLED && mockMode)
+    ? MOCK_STATS
+    : (historyData?.stats ?? {
+        todayScans: 0,
+        seenCount: 0,
+        lastScan: null,
+        totalAlerts: 0,
+        recentMatches: 0,
+      });
+
+  const isLoadingAlerts = (MOCK_ENABLED && mockMode) ? false : loadingHistory;
 
   return (
     <div className="max-w-7xl mx-auto space-y-6">
       {/* Stats Bar */}
       <StatsBar
-        todayScans={stats.todayScans}
-        recentMatches={stats.recentMatches}
-        lastScan={stats.lastScan}
-        seenCount={stats.seenCount}
+        todayScans={displayStats.todayScans}
+        recentMatches={displayStats.recentMatches}
+        lastScan={displayStats.lastScan}
+        seenCount={displayStats.seenCount}
         onScanComplete={fetchHistory}
+        mockMode={mockMode}
+        onToggleMock={toggleMockMode}
       />
 
       {/* Two-column layout */}
       <div className="flex flex-col lg:flex-row gap-6">
-        {/* Left: Alert Feed (~60%) */}
+        {/* Left: Alert Feed */}
         <div className="flex-1 min-w-0">
           <AlertFeed
-            alerts={historyData?.alerts ?? []}
-            loading={loadingHistory}
+            alerts={displayAlerts}
+            loading={isLoadingAlerts}
+            bookmarkedZpids={bookmarkedZpids}
+            onToggleBookmark={handleToggleBookmark}
           />
         </div>
 
-        {/* Right: Filter Panel (~40%) */}
-        <div className="w-full lg:w-80 xl:w-96 shrink-0">
+        {/* Right: Filter Panel */}
+        <div className="w-full lg:w-[320px] lg:flex-shrink-0">
           {loadingPrefs ? (
-            <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 space-y-4 animate-pulse">
-              <div className="h-4 bg-zinc-800 rounded w-1/2" />
-              <div className="h-3 bg-zinc-800 rounded w-3/4" />
+            <div
+              className="rounded-xl p-5 space-y-4 animate-pulse"
+              style={{ background: "#161B22", border: "1px solid #21262D" }}
+            >
+              <div className="h-4 rounded w-1/2" style={{ background: "#1C2430" }} />
+              <div className="h-3 rounded w-3/4" style={{ background: "#1C2430" }} />
               <div className="space-y-2">
                 {[1, 2, 3, 4, 5].map((i) => (
-                  <div key={i} className="h-8 bg-zinc-800 rounded" />
+                  <div key={i} className="h-8 rounded" style={{ background: "#1C2430" }} />
                 ))}
               </div>
             </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,602 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { motion } from "framer-motion";
+import { Check, Cookie, Cloud, AlertCircle } from "lucide-react";
+import { toast } from "sonner";
+import { UserPreferences, DEFAULT_PREFERENCES } from "@/lib/types";
+import {
+  savePrefsToookie,
+  getPrefsFromCookie,
+  clearPrefsCookie,
+} from "@/lib/cookie-prefs";
+
+// ─── Shared style tokens ──────────────────────────────────
+const LABEL: React.CSSProperties = {
+  fontSize: 10,
+  fontWeight: 600,
+  letterSpacing: "0.15em",
+  textTransform: "uppercase",
+  color: "#484F58",
+  fontFamily: "var(--font-inter, sans-serif)",
+  display: "block",
+  marginBottom: 6,
+};
+
+const INPUT: React.CSSProperties = {
+  width: "100%",
+  background: "#0D1117",
+  border: "1px solid #21262D",
+  borderRadius: 8,
+  padding: "9px 12px",
+  fontSize: 14,
+  color: "#E6EDF3",
+  fontFamily: "var(--font-inter, sans-serif)",
+  outline: "none",
+  transition: "border-color 0.15s, box-shadow 0.15s",
+};
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="rounded-xl p-5"
+      style={{ background: "#161B22", border: "1px solid #21262D" }}
+    >
+      <div className="flex items-center gap-2 mb-5">
+        <div className="w-1 h-5 rounded-full" style={{ background: "#39D353" }} />
+        <h2
+          className="font-semibold text-base"
+          style={{ color: "#E6EDF3", fontFamily: "var(--font-space-grotesk, sans-serif)" }}
+        >
+          {title}
+        </h2>
+      </div>
+      <div className="space-y-5">{children}</div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <span style={LABEL}>{label}</span>
+      {children}
+    </div>
+  );
+}
+
+function PillGroup({
+  options,
+  value,
+  onChange,
+}: {
+  options: Array<{ label: string; value: number }>;
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {options.map((opt) => {
+        const sel = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            onClick={() => onChange(opt.value)}
+            className="rounded-md transition-all duration-150"
+            style={{
+              padding: "6px 12px",
+              fontSize: 13,
+              fontFamily: "var(--font-inter, sans-serif)",
+              cursor: "pointer",
+              ...(sel
+                ? { background: "#39D353", color: "#080C10", fontWeight: 600, border: "1px solid #39D353" }
+                : { background: "#1C2430", color: "#8B949E", border: "1px solid #21262D" }),
+            }}
+            onMouseEnter={(e) => {
+              if (!sel) {
+                (e.currentTarget as HTMLButtonElement).style.borderColor = "#30363D";
+                (e.currentTarget as HTMLButtonElement).style.color = "#E6EDF3";
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!sel) {
+                (e.currentTarget as HTMLButtonElement).style.borderColor = "#21262D";
+                (e.currentTarget as HTMLButtonElement).style.color = "#8B949E";
+              }
+            }}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function Toggle({
+  checked,
+  onChange,
+  label,
+  description,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+  description?: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div>
+        <div className="text-sm" style={{ color: "#E6EDF3", fontFamily: "var(--font-inter, sans-serif)" }}>
+          {label}
+        </div>
+        {description && (
+          <div className="mt-0.5" style={{ fontSize: 11, color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}>
+            {description}
+          </div>
+        )}
+      </div>
+      <button
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className="relative inline-flex shrink-0 cursor-pointer rounded-full transition-all duration-200"
+        style={{
+          width: 36, height: 20, padding: 2,
+          background: checked ? "#1A7F37" : "#30363D",
+          border: checked ? "1px solid rgba(57,211,83,0.3)" : "1px solid #484F58",
+          boxShadow: checked ? "0 0 8px rgba(57,211,83,0.2)" : "none",
+        }}
+      >
+        <span
+          className="inline-block rounded-full shadow transition-all duration-200"
+          style={{
+            width: 14, height: 14,
+            background: checked ? "#39D353" : "#8B949E",
+            transform: checked ? "translateX(16px)" : "translateX(0)",
+          }}
+        />
+      </button>
+    </div>
+  );
+}
+
+const BED_OPTIONS  = [1,2,3,4,5].map((n) => ({ label: `${n}+`, value: n }));
+const BATH_OPTIONS = [1, 1.5, 2, 2.5, 3].map((n) => ({ label: `${n}+`, value: n }));
+
+export default function SettingsPage() {
+  const [prefs, setPrefs] = useState<UserPreferences>(DEFAULT_PREFERENCES);
+  const [cookieSaved, setCookieSaved] = useState(false);
+  const [serverSaved, setServerSaved] = useState(false);
+  const [serverError, setServerError] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [source, setSource] = useState<"cookie" | "server" | "default">("default");
+  const cookieTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // On mount: try cookie first, then API
+  useEffect(() => {
+    const cookiePrefs = getPrefsFromCookie();
+    if (cookiePrefs) {
+      setPrefs(cookiePrefs);
+      setSource("cookie");
+      return;
+    }
+    // Fall back to server
+    fetch("/api/preferences")
+      .then((r) => r.json())
+      .then((json: { data?: UserPreferences }) => {
+        if (json.data) {
+          setPrefs(json.data);
+          setSource("server");
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  // Whenever prefs change, auto-save to cookie immediately
+  function updatePrefs(updates: Partial<UserPreferences>) {
+    const next = { ...prefs, ...updates };
+    setPrefs(next);
+    savePrefsToookie(next);
+    setCookieSaved(true);
+    if (cookieTimerRef.current) clearTimeout(cookieTimerRef.current);
+    cookieTimerRef.current = setTimeout(() => setCookieSaved(false), 2000);
+  }
+
+  const syncToServer = useCallback(async () => {
+    setSyncing(true);
+    setServerError(false);
+    try {
+      const res = await fetch("/api/preferences", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(prefs),
+      });
+      const json = await res.json() as { success: boolean };
+      if (json.success) {
+        setServerSaved(true);
+        setTimeout(() => setServerSaved(false), 3000);
+        toast.success("Synced to server");
+      } else {
+        setServerError(true);
+        toast.error("Failed to sync");
+      }
+    } catch {
+      setServerError(true);
+      toast.error("Network error");
+    } finally {
+      setSyncing(false);
+    }
+  }, [prefs]);
+
+  function handleClearCookie() {
+    clearPrefsCookie();
+    toast("Cookie cleared", { description: "Settings will be loaded from server next visit" });
+  }
+
+  function focusInput(e: React.FocusEvent<HTMLInputElement>) {
+    e.target.style.borderColor = "#39D353";
+    e.target.style.boxShadow = "0 0 0 1px rgba(57,211,83,0.3)";
+  }
+  function blurInput(e: React.FocusEvent<HTMLInputElement>) {
+    e.target.style.borderColor = "#21262D";
+    e.target.style.boxShadow = "none";
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      {/* Page header */}
+      <div
+        className="-mx-6 -mt-6 px-6 py-4 mb-6 flex items-center justify-between"
+        style={{ background: "#0D1117", borderBottom: "1px solid #21262D" }}
+      >
+        <div className="flex items-center gap-2">
+          <div className="w-1 h-5 rounded-full" style={{ background: "#39D353" }} />
+          <h1
+            className="text-2xl font-semibold"
+            style={{ fontFamily: "var(--font-space-grotesk, sans-serif)", color: "#E6EDF3" }}
+          >
+            Settings
+          </h1>
+        </div>
+
+        {/* Persistence status */}
+        <div className="flex items-center gap-3">
+          {cookieSaved && (
+            <motion.div
+              initial={{ opacity: 0, y: -4 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="flex items-center gap-1.5 text-xs"
+              style={{ color: "#39D353", fontFamily: "var(--font-inter, sans-serif)" }}
+            >
+              <Cookie size={12} />
+              Saved to cookie
+            </motion.div>
+          )}
+          {source !== "default" && (
+            <span
+              className="text-[11px] px-2 py-1 rounded"
+              style={{
+                background: "#161B22",
+                border: "1px solid #21262D",
+                color: "#484F58",
+                fontFamily: "var(--font-inter, sans-serif)",
+              }}
+            >
+              loaded from {source}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Cookie persistence info banner */}
+      <div
+        className="flex items-start gap-3 rounded-xl px-4 py-3 mb-6 text-sm"
+        style={{
+          background: "rgba(57,211,83,0.04)",
+          border: "1px solid rgba(57,211,83,0.15)",
+          fontFamily: "var(--font-inter, sans-serif)",
+        }}
+      >
+        <Cookie size={15} style={{ color: "#39D353", flexShrink: 0, marginTop: 1 }} />
+        <div>
+          <span style={{ color: "#E6EDF3", fontWeight: 500 }}>Settings auto-save to a cookie</span>
+          <span style={{ color: "#8B949E" }}>
+            {" "}— your preferences persist across sessions instantly, no account needed.
+            Use <strong style={{ color: "#E6EDF3" }}>Sync to Server</strong> to also save them
+            to your Vercel KV store (survives clearing cookies).
+          </span>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {/* ── Notifications ─────────────────────────────── */}
+        <Section title="Notifications">
+          <Field label="Alert Email">
+            <input
+              type="email"
+              value={prefs.alertEmail}
+              placeholder="you@example.com"
+              onChange={(e) => updatePrefs({ alertEmail: e.target.value })}
+              style={INPUT}
+              onFocus={focusInput}
+              onBlur={blurInput}
+              aria-label="Alert email"
+            />
+            <p className="mt-1.5" style={{ fontSize: 11, color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}>
+              HOT listings are emailed individually. MATCH listings arrive as a digest.
+            </p>
+          </Field>
+
+          <Field label="AI Score threshold">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span style={{ fontSize: 10, color: "#484F58", width: 30, fontFamily: "var(--font-inter, sans-serif)" }}>alert</span>
+                <input
+                  type="range" min={1} max={10} step={1}
+                  value={prefs.scoreThreshold}
+                  onChange={(e) => updatePrefs({
+                    scoreThreshold: Number(e.target.value),
+                    hotScoreThreshold: Math.max(Number(e.target.value) + 1, prefs.hotScoreThreshold),
+                  })}
+                  className="custom-slider flex-1"
+                  aria-label="Alert threshold"
+                />
+                <span style={{ fontSize: 13, fontWeight: 700, color: "#39D353", fontFamily: "var(--font-mono, monospace)", width: 20 }}>
+                  {prefs.scoreThreshold}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span style={{ fontSize: 10, color: "#484F58", width: 30, fontFamily: "var(--font-inter, sans-serif)" }}>hot</span>
+                <input
+                  type="range" min={1} max={10} step={1}
+                  value={prefs.hotScoreThreshold}
+                  onChange={(e) => updatePrefs({
+                    hotScoreThreshold: Math.max(Number(e.target.value), prefs.scoreThreshold + 1),
+                  })}
+                  className="custom-slider flex-1"
+                  aria-label="HOT threshold"
+                />
+                <span style={{ fontSize: 13, fontWeight: 700, color: "#39D353", fontFamily: "var(--font-mono, monospace)", width: 20 }}>
+                  {prefs.hotScoreThreshold}
+                </span>
+              </div>
+            </div>
+            <p className="mt-2" style={{ fontSize: 11, color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}>
+              Only listings scoring ≥ {prefs.scoreThreshold} trigger alerts. Scores ≥ {prefs.hotScoreThreshold} are flagged HOT.
+            </p>
+          </Field>
+        </Section>
+
+        {/* ── Search Criteria ────────────────────────────── */}
+        <Section title="Search Criteria">
+          <Field label="Search Area">
+            <input
+              type="text"
+              value={prefs.searchArea}
+              placeholder="Frisco, TX"
+              onChange={(e) => updatePrefs({ searchArea: e.target.value })}
+              style={INPUT}
+              onFocus={focusInput}
+              onBlur={blurInput}
+              aria-label="Search area"
+            />
+          </Field>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field label={`Min Price`}>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm" style={{ color: "#484F58" }}>$</span>
+                <input
+                  type="number"
+                  value={prefs.minPrice}
+                  min={0}
+                  step={25000}
+                  onChange={(e) => updatePrefs({ minPrice: Number(e.target.value) })}
+                  style={{ ...INPUT, paddingLeft: 24 }}
+                  onFocus={focusInput}
+                  onBlur={blurInput}
+                  aria-label="Minimum price"
+                />
+              </div>
+            </Field>
+            <Field label="Max Price">
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm" style={{ color: "#484F58" }}>$</span>
+                <input
+                  type="number"
+                  value={prefs.maxPrice}
+                  min={0}
+                  step={25000}
+                  onChange={(e) => updatePrefs({ maxPrice: Number(e.target.value) })}
+                  style={{ ...INPUT, paddingLeft: 24 }}
+                  onFocus={focusInput}
+                  onBlur={blurInput}
+                  aria-label="Maximum price"
+                />
+              </div>
+            </Field>
+          </div>
+
+          <Field label="Min Bedrooms">
+            <PillGroup
+              options={BED_OPTIONS}
+              value={prefs.minBeds}
+              onChange={(v) => updatePrefs({ minBeds: v })}
+            />
+          </Field>
+
+          <Field label="Min Bathrooms">
+            <PillGroup
+              options={BATH_OPTIONS}
+              value={prefs.minBaths}
+              onChange={(v) => updatePrefs({ minBaths: v })}
+            />
+          </Field>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Min Sqft">
+              <input
+                type="number"
+                value={prefs.minSqft}
+                min={0}
+                step={100}
+                onChange={(e) => updatePrefs({ minSqft: Number(e.target.value) })}
+                style={INPUT}
+                onFocus={focusInput}
+                onBlur={blurInput}
+                aria-label="Minimum square feet"
+              />
+            </Field>
+            <Field label="Min Year Built">
+              <input
+                type="number"
+                value={prefs.minYearBuilt}
+                min={1900}
+                max={2024}
+                step={1}
+                onChange={(e) => updatePrefs({ minYearBuilt: Number(e.target.value) })}
+                style={INPUT}
+                onFocus={focusInput}
+                onBlur={blurInput}
+                aria-label="Minimum year built"
+              />
+            </Field>
+          </div>
+
+          <Toggle
+            label="Require Garage"
+            description="Only show listings that include a garage"
+            checked={prefs.requireGarage}
+            onChange={(v) => updatePrefs({ requireGarage: v })}
+          />
+
+          <Toggle
+            label="Max HOA Limit"
+            description="Filter out listings above a monthly HOA threshold"
+            checked={prefs.maxHoa !== null}
+            onChange={(v) => updatePrefs({ maxHoa: v ? 200 : null })}
+          />
+          {prefs.maxHoa !== null && (
+            <div className="flex items-center gap-2 -mt-2">
+              <span style={{ fontSize: 12, color: "#484F58" }}>$</span>
+              <input
+                type="number"
+                value={prefs.maxHoa}
+                min={0}
+                step={25}
+                onChange={(e) => updatePrefs({ maxHoa: Math.max(0, Number(e.target.value)) })}
+                style={INPUT}
+                onFocus={focusInput}
+                onBlur={blurInput}
+                aria-label="Max HOA per month"
+              />
+              <span style={{ fontSize: 12, color: "#484F58", whiteSpace: "nowrap" }}>/mo</span>
+            </div>
+          )}
+        </Section>
+
+        {/* ── Sync & persistence ────────────────────────── */}
+        <Section title="Data & Persistence">
+          <div className="flex flex-col sm:flex-row gap-3">
+            {/* Sync to server */}
+            <button
+              onClick={() => void syncToServer()}
+              disabled={syncing}
+              className="flex items-center justify-center gap-2 rounded-lg font-semibold text-sm transition-all duration-150 flex-1 disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                padding: "10px 20px",
+                background: "#39D353",
+                color: "#080C10",
+                fontFamily: "var(--font-inter, sans-serif)",
+                border: "none",
+                cursor: "pointer",
+              }}
+              onMouseEnter={(e) => {
+                if (!syncing) {
+                  (e.currentTarget as HTMLButtonElement).style.filter = "brightness(1.1)";
+                  (e.currentTarget as HTMLButtonElement).style.boxShadow = "0 0 16px rgba(57,211,83,0.35)";
+                }
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.filter = "brightness(1)";
+                (e.currentTarget as HTMLButtonElement).style.boxShadow = "none";
+              }}
+            >
+              {syncing ? (
+                <>
+                  <span className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                  Syncing…
+                </>
+              ) : serverSaved ? (
+                <><Check size={14} /> Synced to server</>
+              ) : (
+                <><Cloud size={14} /> Sync to Server</>
+              )}
+            </button>
+
+            {/* Clear cookie */}
+            <button
+              onClick={handleClearCookie}
+              className="flex items-center justify-center gap-2 rounded-lg text-sm font-medium transition-all duration-150"
+              style={{
+                padding: "10px 20px",
+                background: "#161B22",
+                color: "#8B949E",
+                border: "1px solid #21262D",
+                fontFamily: "var(--font-inter, sans-serif)",
+                cursor: "pointer",
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.borderColor = "#30363D";
+                (e.currentTarget as HTMLButtonElement).style.color = "#E6EDF3";
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.borderColor = "#21262D";
+                (e.currentTarget as HTMLButtonElement).style.color = "#8B949E";
+              }}
+            >
+              <Cookie size={14} />
+              Clear Cookie
+            </button>
+          </div>
+
+          {serverError && (
+            <div
+              className="flex items-center gap-2 rounded-lg px-3 py-2 text-xs"
+              style={{
+                background: "rgba(255,107,53,0.06)",
+                border: "1px solid rgba(255,107,53,0.2)",
+                color: "#FF6B35",
+                fontFamily: "var(--font-inter, sans-serif)",
+              }}
+            >
+              <AlertCircle size={12} />
+              Server sync failed — settings are still saved in your cookie.
+            </div>
+          )}
+
+          <div
+            className="text-xs space-y-1.5"
+            style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}
+          >
+            <p>
+              <span style={{ color: "#8B949E" }}>Cookie</span>
+              {" "}— instant local persistence, 30-day expiry, no server required.
+            </p>
+            <p>
+              <span style={{ color: "#8B949E" }}>Server sync</span>
+              {" "}— saves to Vercel KV, shared across devices, survives cookie clears.
+            </p>
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/AlertFeed.tsx
+++ b/components/dashboard/AlertFeed.tsx
@@ -1,48 +1,66 @@
 "use client";
 
-import { Bell } from "lucide-react";
-import { AlertRecord } from "@/lib/types";
+import { AlertRecord, AIScoredListing } from "@/lib/types";
 import { ListingCard } from "./ListingCard";
 import { EmptyState } from "./EmptyState";
 
 interface AlertFeedProps {
   alerts: AlertRecord[];
   loading?: boolean;
+  bookmarkedZpids?: Set<string>;
+  onToggleBookmark?: (listing: AIScoredListing) => void;
 }
 
 function SkeletonCard() {
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden animate-pulse">
-      <div className="h-40 bg-zinc-800" />
+    <div
+      className="rounded-xl overflow-hidden animate-pulse"
+      style={{ background: "#161B22", border: "1px solid #21262D" }}
+    >
+      <div className="h-40" style={{ background: "#1C2430" }} />
       <div className="p-4 space-y-3">
-        <div className="flex justify-between">
-          <div className="h-4 bg-zinc-800 rounded w-3/4" />
-          <div className="h-4 bg-zinc-800 rounded w-1/5" />
+        <div className="flex justify-between gap-2">
+          <div className="h-3.5 rounded w-3/4" style={{ background: "#1C2430" }} />
+          <div className="h-3.5 rounded w-1/5" style={{ background: "#1C2430" }} />
         </div>
         <div className="flex gap-3">
           {[1, 2, 3, 4].map((i) => (
-            <div key={i} className="h-3 bg-zinc-800 rounded w-12" />
+            <div key={i} className="h-2.5 rounded w-10" style={{ background: "#1C2430" }} />
           ))}
         </div>
-        <div className="h-3 bg-zinc-800 rounded w-full" />
-        <div className="h-3 bg-zinc-800 rounded w-4/5" />
+        <div className="h-2.5 rounded w-full" style={{ background: "#1C2430" }} />
+        <div className="h-2.5 rounded w-4/5" style={{ background: "#1C2430" }} />
       </div>
     </div>
   );
 }
 
-export function AlertFeed({ alerts, loading }: AlertFeedProps) {
+export function AlertFeed({ alerts, loading, bookmarkedZpids, onToggleBookmark }: AlertFeedProps) {
   return (
     <section aria-label="Alert history">
-      {/* Title */}
-      <div className="flex items-center gap-2 mb-4">
-        <Bell size={16} className="text-zinc-500" />
-        <h2 className="text-zinc-100 font-semibold">Alert History</h2>
-        {alerts.length > 0 && (
-          <span className="ml-1 px-1.5 py-0.5 rounded-full bg-zinc-800 text-zinc-400 text-[11px] font-medium">
-            {alerts.length}
-          </span>
-        )}
+      {/* Section heading */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-2">
+          <div
+            className="w-1 h-5 rounded-full"
+            style={{ background: "#39D353" }}
+          />
+          <h2
+            className="font-semibold text-base"
+            style={{
+              color: "#E6EDF3",
+              fontFamily: "var(--font-space-grotesk, sans-serif)",
+            }}
+          >
+            Alert History
+          </h2>
+        </div>
+        <span
+          className="text-xs"
+          style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}
+        >
+          {alerts.length} total
+        </span>
       </div>
 
       {/* Content */}
@@ -55,9 +73,15 @@ export function AlertFeed({ alerts, loading }: AlertFeedProps) {
       ) : alerts.length === 0 ? (
         <EmptyState />
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div className="alert-grid grid grid-cols-1 sm:grid-cols-2 gap-4">
           {alerts.map((record, i) => (
-            <ListingCard key={record.id} record={record} index={i} />
+            <ListingCard
+              key={record.id}
+              record={record}
+              index={i}
+              isBookmarked={bookmarkedZpids?.has(record.listing.id)}
+              onToggleBookmark={onToggleBookmark}
+            />
           ))}
         </div>
       )}

--- a/components/dashboard/EmptyState.tsx
+++ b/components/dashboard/EmptyState.tsx
@@ -1,29 +1,110 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Eye } from "lucide-react";
+
+const lines = [
+  { prompt: true,  text: "hyh status" },
+  { prompt: false, text: "◆ agent online" },
+  { prompt: false, text: "◆ scanning zillow 4× daily" },
+  { prompt: false, text: "◆ 0 matches found — waiting..." },
+];
 
 export function EmptyState() {
   return (
     <motion.div
-      initial={{ opacity: 0, y: 16 }}
+      initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4 }}
-      className="flex flex-col items-center justify-center py-24 text-center"
+      transition={{ duration: 0.3 }}
+      className="flex flex-col items-center justify-center min-h-[400px] w-full"
     >
-      <div className="w-16 h-16 rounded-2xl bg-zinc-800 border border-zinc-700 flex items-center justify-center mb-4">
-        <Eye size={28} className="text-zinc-500" />
-      </div>
-      <h3 className="text-zinc-100 text-lg font-semibold mb-1">
-        No alerts yet
+      {/* Terminal window */}
+      <motion.div
+        initial={{ scale: 0.97 }}
+        animate={{ scale: 1 }}
+        transition={{ delay: 0.08, duration: 0.25 }}
+        className="max-w-sm w-full mx-auto rounded-xl overflow-hidden text-left"
+        style={{ background: "#0D1117", border: "1px solid #21262D" }}
+      >
+        {/* macOS title bar */}
+        <div
+          className="flex items-center gap-1.5 px-4 py-2.5"
+          style={{ background: "#161B22", borderBottom: "1px solid #21262D" }}
+        >
+          <span className="w-3 h-3 rounded-full" style={{ background: "#FF5F57" }} />
+          <span className="w-3 h-3 rounded-full" style={{ background: "#FEBC2E" }} />
+          <span className="w-3 h-3 rounded-full" style={{ background: "#28C840" }} />
+          <span
+            className="ml-2 text-xs"
+            style={{ color: "#8B949E", fontFamily: "var(--font-mono, monospace)" }}
+          >
+            hyh-agent — bash
+          </span>
+        </div>
+
+        {/* Terminal body */}
+        <div
+          className="px-4 py-4 space-y-1.5"
+          style={{ fontFamily: "var(--font-mono, monospace)", fontSize: 13 }}
+        >
+          {lines.map((line, i) => (
+            <motion.p
+              key={i}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ delay: 0.3 + i * 0.25 }}
+            >
+              {line.prompt ? (
+                <span style={{ color: "#39D353" }}>
+                  <span style={{ color: "#484F58" }}>$ </span>
+                  {line.text}
+                </span>
+              ) : (
+                <span style={{ color: "#E6EDF3" }}>{line.text}</span>
+              )}
+            </motion.p>
+          ))}
+
+          {/* Blinking cursor */}
+          <motion.p
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 1.35 }}
+            className="flex items-center"
+          >
+            <span style={{ color: "#484F58", fontFamily: "var(--font-mono, monospace)" }}>$ </span>
+            <span
+              className="inline-block w-2 h-[14px] bg-accent animate-pulse ml-1 rounded-sm align-middle"
+              style={{ background: "#39D353" }}
+            />
+          </motion.p>
+        </div>
+      </motion.div>
+
+      {/* Text below terminal */}
+      <h3
+        className="text-xl font-semibold text-center mt-6 mb-2"
+        style={{ color: "#E6EDF3", fontFamily: "var(--font-space-grotesk, sans-serif)" }}
+      >
+        No alerts yet.
       </h3>
-      <p className="text-zinc-500 text-sm max-w-xs">
-        Your agent is watching. New listings that match your criteria will appear
-        here.
+      <p
+        className="text-sm text-center max-w-xs mx-auto"
+        style={{ color: "#8B949E", fontFamily: "var(--font-inter, sans-serif)" }}
+      >
+        Your agent is watching. New listings matching your criteria will appear here.
       </p>
-      <div className="mt-6 flex items-center gap-2 text-xs text-zinc-600">
-        <div className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
-        Agent active — scanning 4× daily
+
+      <div className="flex items-center justify-center gap-1.5 mt-4">
+        <span
+          className="w-1.5 h-1.5 rounded-full animate-pulse"
+          style={{ background: "#39D353", boxShadow: "0 0 4px #39D353" }}
+        />
+        <span
+          className="text-xs"
+          style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}
+        >
+          agent active — scanning 4× daily
+        </span>
       </div>
     </motion.div>
   );

--- a/components/dashboard/ListingCard.tsx
+++ b/components/dashboard/ListingCard.tsx
@@ -1,50 +1,89 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { ExternalLink, Bed, Bath, Maximize2, Calendar } from "lucide-react";
+import { ExternalLink, Bed, Bath, Maximize2, Calendar, Star } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import Image from "next/image";
-import { AlertRecord } from "@/lib/types";
+import { AlertRecord, AIScoredListing } from "@/lib/types";
 
 interface ListingCardProps {
   record: AlertRecord;
   index?: number;
+  isBookmarked?: boolean;
+  onToggleBookmark?: (listing: AIScoredListing) => void;
+  showSoldBanner?: boolean;
 }
 
-function ScoreBadge({ score }: { score: number }) {
-  const color =
-    score >= 8
-      ? "bg-brand/15 text-brand border-brand/30"
-      : score >= 6
-      ? "bg-zinc-700/50 text-zinc-300 border-zinc-600"
-      : "bg-zinc-800/50 text-zinc-500 border-zinc-700";
-
+function ScoreBadge({ score, tier }: { score: number; tier: "HOT" | "MATCH" }) {
+  const isHot = tier === "HOT";
   return (
     <div
-      className={`flex items-center gap-1 px-2 py-0.5 rounded-md border text-xs font-semibold ${color}`}
+      className="flex items-center gap-1 px-2 py-0.5 rounded-md border text-[11px] font-bold min-h-[22px]"
+      style={
+        isHot
+          ? {
+              background: "rgba(57,211,83,0.1)",
+              borderColor: "rgba(57,211,83,0.25)",
+              color: "#39D353",
+            }
+          : {
+              background: "rgba(88,166,255,0.1)",
+              borderColor: "rgba(88,166,255,0.25)",
+              color: "#58A6FF",
+            }
+      }
     >
-      <span className="text-[10px] font-normal opacity-70">AI</span>
-      {score}
-      <span className="text-[10px] font-normal opacity-70">/10</span>
+      <span
+        className="opacity-50 font-normal text-[9px] uppercase tracking-wide"
+        style={{ fontFamily: "var(--font-inter, sans-serif)" }}
+      >
+        AI
+      </span>
+      <span style={{ fontFamily: "var(--font-space-grotesk, sans-serif)", fontSize: 12 }}>
+        {score}/10
+      </span>
     </div>
   );
 }
 
 function TierBadge({ tier }: { tier: "HOT" | "MATCH" }) {
   return tier === "HOT" ? (
-    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-brand/15 text-brand border border-brand/30 text-[11px] font-semibold">
+    <span
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold tracking-wider"
+      style={{
+        background: "rgba(255,107,53,0.1)",
+        border: "1px solid rgba(255,107,53,0.2)",
+        color: "#FF6B35",
+        fontFamily: "var(--font-inter, sans-serif)",
+      }}
+    >
       🔥 HOT
     </span>
   ) : (
-    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-zinc-700/40 text-zinc-300 border border-zinc-700 text-[11px] font-semibold">
+    <span
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold tracking-wider"
+      style={{
+        background: "rgba(88,166,255,0.1)",
+        border: "1px solid rgba(88,166,255,0.2)",
+        color: "#58A6FF",
+        fontFamily: "var(--font-inter, sans-serif)",
+      }}
+    >
       ✦ MATCH
     </span>
   );
 }
 
-export function ListingCard({ record, index = 0 }: ListingCardProps) {
+export function ListingCard({
+  record,
+  index = 0,
+  isBookmarked = false,
+  onToggleBookmark,
+  showSoldBanner = false,
+}: ListingCardProps) {
   const { listing, sentAt } = record;
   const photoUrl = listing.photos?.[0];
+  const shortAddress = listing.address.replace(/,\s*Frisco,?\s*TX\s*\d*/i, "").trim();
   const timeAgo = formatDistanceToNow(new Date(sentAt), { addSuffix: true });
   const pricePerSqft =
     listing.pricePerSqft ??
@@ -52,78 +91,189 @@ export function ListingCard({ record, index = 0 }: ListingCardProps) {
 
   return (
     <motion.article
-      initial={{ opacity: 0, y: 12 }}
+      initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.3, delay: index * 0.05 }}
-      className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden hover:border-zinc-700 transition-colors group"
+      transition={{ duration: 0.25, delay: index * 0.07 }}
+      className="rounded-xl overflow-hidden group"
+      style={{
+        background: "#161B22",
+        border: "1px solid #21262D",
+        transition: "border-color 200ms ease, box-shadow 200ms ease, transform 200ms ease",
+        opacity: showSoldBanner ? 0.85 : 1,
+      }}
+      onMouseEnter={(e) => {
+        const el = e.currentTarget as HTMLElement;
+        el.style.borderColor = "#30363D";
+        el.style.transform = "translateY(-1px)";
+        el.style.boxShadow = "0 4px 24px rgba(0,0,0,0.4)";
+      }}
+      onMouseLeave={(e) => {
+        const el = e.currentTarget as HTMLElement;
+        el.style.borderColor = "#21262D";
+        el.style.transform = "translateY(0)";
+        el.style.boxShadow = "none";
+      }}
       aria-label={`Listing: ${listing.address}`}
     >
       {/* Photo */}
-      <div className="relative h-40 bg-zinc-800 overflow-hidden">
+      <div
+        className="relative h-40 overflow-hidden"
+        style={{ background: "#1C2430" }}
+      >
         {photoUrl ? (
           <Image
             src={photoUrl}
             alt={listing.address}
             fill
-            className="object-cover group-hover:scale-105 transition-transform duration-300"
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
             sizes="(max-width: 768px) 100vw, 600px"
             unoptimized
           />
         ) : (
           <div className="absolute inset-0 flex items-center justify-center">
-            <div className="w-12 h-12 rounded-xl bg-zinc-700 flex items-center justify-center">
-              <span className="text-zinc-500 text-xl">🏠</span>
+            <div
+              className="w-10 h-10 rounded-lg flex items-center justify-center"
+              style={{ background: "#21262D" }}
+            >
+              <span className="text-lg">🏠</span>
             </div>
           </div>
         )}
-        {/* Overlay badges */}
-        <div className="absolute top-2 left-2 flex items-center gap-1.5">
+        {/* Bottom gradient */}
+        <div
+          className="absolute inset-0"
+          style={{
+            background: "linear-gradient(to top, rgba(22,27,34,0.7) 0%, transparent 50%)",
+          }}
+        />
+
+        {/* SOLD banner */}
+        {showSoldBanner && (
+          <div
+            className="absolute inset-0 flex items-center justify-center"
+            style={{ background: "rgba(180,28,28,0.82)", zIndex: 10 }}
+          >
+            <span
+              className="font-black tracking-widest text-white text-xl"
+              style={{ fontFamily: "var(--font-space-grotesk, sans-serif)", letterSpacing: "0.12em" }}
+            >
+              HOME SOLD
+            </span>
+          </div>
+        )}
+
+        <div className="absolute top-2 left-2" style={{ zIndex: 5 }}>
           <TierBadge tier={listing.alertTier} />
         </div>
-        <div className="absolute top-2 right-2">
-          <ScoreBadge score={listing.aiScore} />
+        <div className="absolute top-2 right-2" style={{ zIndex: 5 }}>
+          <ScoreBadge score={listing.aiScore} tier={listing.alertTier} />
         </div>
+
+        {/* Bookmark star */}
+        {onToggleBookmark && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleBookmark(listing);
+            }}
+            className="absolute bottom-2 right-2"
+            style={{ zIndex: 5 }}
+            aria-label={isBookmarked ? "Remove bookmark" : "Save home"}
+          >
+            <motion.div
+              whileTap={{ scale: 0.85 }}
+              className="w-7 h-7 rounded-full flex items-center justify-center"
+              style={{
+                background: isBookmarked
+                  ? "rgba(57,211,83,0.2)"
+                  : "rgba(13,17,23,0.7)",
+                border: isBookmarked
+                  ? "1px solid rgba(57,211,83,0.4)"
+                  : "1px solid rgba(255,255,255,0.1)",
+                backdropFilter: "blur(4px)",
+                transition: "background 200ms ease, border-color 200ms ease",
+              }}
+            >
+              <Star
+                size={13}
+                fill={isBookmarked ? "#39D353" : "none"}
+                stroke={isBookmarked ? "#39D353" : "#8B949E"}
+                strokeWidth={2}
+              />
+            </motion.div>
+          </button>
+        )}
       </div>
 
       {/* Content */}
       <div className="p-4">
         {/* Address & Price */}
-        <div className="flex items-start justify-between gap-2 mb-2">
-          <h3 className="text-zinc-100 font-semibold text-sm leading-snug line-clamp-2 flex-1">
-            {listing.address}
+        <div className="flex items-start justify-between gap-2 mb-2.5">
+          <h3
+            className="text-sm font-medium truncate flex-1"
+            style={{
+              color: "#E6EDF3",
+              fontFamily: "var(--font-space-grotesk, sans-serif)",
+            }}
+          >
+            {shortAddress}
           </h3>
           <div className="shrink-0 text-right">
-            <div className="text-brand font-bold text-base">
+            <div
+              className="font-black text-2xl"
+              style={{
+                color: "#E6EDF3",
+                fontFamily: "var(--font-price, var(--font-space-grotesk), sans-serif)",
+                letterSpacing: "-0.02em",
+              }}
+            >
               ${listing.price.toLocaleString()}
             </div>
             {pricePerSqft && (
-              <div className="text-zinc-500 text-xs">${pricePerSqft}/sqft</div>
+              <div
+                className="text-xs"
+                style={{
+                  color: "#8B949E",
+                  fontFamily: "var(--font-inter, sans-serif)",
+                }}
+              >
+                ${pricePerSqft}/sqft
+              </div>
             )}
           </div>
         </div>
 
-        {/* Stats */}
-        <div className="flex items-center gap-3 text-xs text-zinc-400 mb-3">
-          <span className="flex items-center gap-1">
-            <Bed size={12} className="text-zinc-600" />
+        {/* Stats row */}
+        <div
+          className="flex items-center text-xs mb-2.5"
+          style={{ fontFamily: "var(--font-inter, sans-serif)" }}
+        >
+          <span className="flex items-center gap-1 text-content-secondary">
+            <Bed size={12} className="text-content-muted w-3 h-3" />
             {listing.beds} bd
           </span>
-          <span className="flex items-center gap-1">
-            <Bath size={12} className="text-zinc-600" />
+          <span className="text-content-muted mx-0.5 select-none" aria-hidden="true">·</span>
+          <span className="flex items-center gap-1 text-content-secondary">
+            <Bath size={12} className="text-content-muted w-3 h-3" />
             {listing.baths} ba
           </span>
-          <span className="flex items-center gap-1">
-            <Maximize2 size={12} className="text-zinc-600" />
+          <span className="text-content-muted mx-0.5 select-none" aria-hidden="true">·</span>
+          <span className="flex items-center gap-1 text-content-secondary">
+            <Maximize2 size={12} className="text-content-muted w-3 h-3" />
             {listing.sqft.toLocaleString()} sqft
           </span>
-          <span className="flex items-center gap-1">
-            <Calendar size={12} className="text-zinc-600" />
+          <span className="text-content-muted mx-0.5 select-none" aria-hidden="true">·</span>
+          <span className="flex items-center gap-1 text-content-secondary">
+            <Calendar size={12} className="text-content-muted w-3 h-3" />
             {listing.yearBuilt}
           </span>
         </div>
 
         {/* AI Reason */}
-        <p className="text-zinc-500 text-xs leading-relaxed line-clamp-2 mb-3">
+        <p
+          className="text-xs leading-relaxed line-clamp-2 mb-3"
+          style={{ color: "#8B949E", fontFamily: "var(--font-inter, sans-serif)" }}
+        >
           {listing.aiReason}
         </p>
 
@@ -133,7 +283,14 @@ export function ListingCard({ record, index = 0 }: ListingCardProps) {
             {listing.aiHighlights.slice(0, 3).map((h, i) => (
               <span
                 key={i}
-                className="text-[10px] px-1.5 py-0.5 bg-green-950/40 text-green-400 border border-green-900/50 rounded"
+                className="text-[10px] px-1.5 py-0.5 rounded-md"
+                style={{
+                  background: "rgba(57,211,83,0.06)",
+                  border: "1px solid rgba(57,211,83,0.15)",
+                  color: "#39D353",
+                  fontFamily: "var(--font-inter, sans-serif)",
+                  opacity: 0.85,
+                }}
               >
                 {h}
               </span>
@@ -142,17 +299,28 @@ export function ListingCard({ record, index = 0 }: ListingCardProps) {
         )}
 
         {/* Footer */}
-        <div className="flex items-center justify-between pt-2 border-t border-zinc-800">
-          <span className="text-[11px] text-zinc-600">{timeAgo}</span>
+        <div
+          className="flex items-center justify-between pt-2.5"
+          style={{ borderTop: "1px solid #21262D" }}
+        >
+          <span
+            className="text-[11px]"
+            style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}
+          >
+            {timeAgo}
+          </span>
           <a
             href={listing.zillowUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-1 text-xs text-brand hover:text-brand-light font-medium transition-colors"
+            className="flex items-center gap-1 text-xs font-medium transition-colors duration-150 underline-offset-2 hover:underline"
+            style={{ color: "#006AFF", fontFamily: "var(--font-inter, sans-serif)" }}
+            onMouseEnter={(e) => ((e.currentTarget as HTMLAnchorElement).style.color = "#0041D9")}
+            onMouseLeave={(e) => ((e.currentTarget as HTMLAnchorElement).style.color = "#006AFF")}
             aria-label={`View ${listing.address} on Zillow`}
           >
             View on Zillow
-            <ExternalLink size={11} />
+            <ExternalLink size={10} />
           </a>
         </div>
       </div>

--- a/components/dashboard/StatsBar.tsx
+++ b/components/dashboard/StatsBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Scan, Bell, Clock, Database, RefreshCw } from "lucide-react";
+import { Scan, Bell, Clock, Database, Zap, FlaskConical } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -13,43 +13,70 @@ interface StatsBarProps {
   lastScan: ScanRecord | null;
   seenCount: number;
   onScanComplete?: () => void;
+  mockMode?: boolean;
+  onToggleMock?: () => void;
 }
 
 interface StatCardProps {
   icon: React.ElementType;
   label: string;
   value: string | number;
-  accent?: boolean;
+  isActive?: boolean;  // drives accent color + top border
+  italic?: boolean;
   delay?: number;
 }
 
-function StatCard({ icon: Icon, label, value, accent, delay = 0 }: StatCardProps) {
+function StatCard({ icon: Icon, label, value, isActive, italic, delay = 0 }: StatCardProps) {
   return (
     <motion.div
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.3, delay }}
-      className="flex items-center gap-3 bg-zinc-900 border border-zinc-800 rounded-xl px-4 py-3 flex-1 min-w-0"
+      transition={{ duration: 0.25, delay }}
+      className="rounded-xl flex-1 min-w-0 cursor-default"
+      style={{
+        background: "#161B22",
+        border: "1px solid #21262D",
+        borderTop: isActive ? "2px solid #39D353" : "2px solid #21262D",
+        padding: "16px 20px",
+        transition: "border-color 200ms, box-shadow 200ms",
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLDivElement).style.borderColor = "#30363D";
+        (e.currentTarget as HTMLDivElement).style.boxShadow = "0 0 0 1px #30363D";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLDivElement).style.borderColor = isActive ? "#39D353" : "#21262D";
+        (e.currentTarget as HTMLDivElement).style.boxShadow = "none";
+      }}
     >
-      <div
-        className={`w-8 h-8 rounded-lg flex items-center justify-center shrink-0 ${
-          accent ? "bg-brand/15" : "bg-zinc-800"
-        }`}
-      >
-        <Icon
-          size={16}
-          className={accent ? "text-brand" : "text-zinc-400"}
-        />
-      </div>
-      <div className="min-w-0">
-        <div className="text-xs text-zinc-500 truncate">{label}</div>
-        <div
-          className={`text-lg font-semibold leading-tight ${
-            accent ? "text-brand" : "text-zinc-100"
-          }`}
+      {/* Icon + label row */}
+      <div className="flex items-center gap-1.5 mb-2">
+        <Icon size={14} style={{ color: "#484F58", flexShrink: 0 }} />
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            letterSpacing: "0.1em",
+            textTransform: "uppercase" as const,
+            color: "#8B949E",
+            fontFamily: "var(--font-inter, sans-serif)",
+          }}
         >
-          {value}
-        </div>
+          {label}
+        </span>
+      </div>
+      {/* Value */}
+      <div
+        style={{
+          fontSize: italic ? 16 : 36,
+          fontWeight: 700,
+          lineHeight: 1,
+          color: isActive ? "#39D353" : italic ? "#8B949E" : "#E6EDF3",
+          fontFamily: "var(--font-space-grotesk, sans-serif)",
+          fontStyle: italic ? "italic" : "normal",
+        }}
+      >
+        {value}
       </div>
     </motion.div>
   );
@@ -61,27 +88,42 @@ export function StatsBar({
   lastScan,
   seenCount,
   onScanComplete,
+  mockMode = false,
+  onToggleMock,
 }: StatsBarProps) {
   const [scanning, setScanning] = useState(false);
 
-  const lastScanLabel = lastScan
+  const rawLastScan = lastScan
     ? formatDistanceToNow(new Date(lastScan.runAt), { addSuffix: true })
-    : "Never";
+    : "never";
+  const lastScanValue =
+    rawLastScan === "never"
+      ? "never"
+      : rawLastScan
+          .replace(" minutes", "m")
+          .replace(" hours", "h")
+          .replace(" days", "d")
+          .replace(" seconds", "s")
+          .replace(" minute", "m")
+          .replace(" hour", "h")
+          .replace(" day", "d")
+          .replace(" second", "s");
+  const lastScanIsNever = !lastScan;
 
   async function handleScanNow() {
+    if (mockMode) {
+      toast("Mock mode is on", { description: "Disable mock mode to run a real scan" });
+      return;
+    }
     setScanning(true);
     toast("Scan started...", { description: "Checking Zillow for new listings" });
-
     try {
       const res = await fetch("/api/scrape", { method: "POST" });
       const json = await res.json() as { success: boolean; data?: ScanRecord; error?: string };
-
       if (json.success && json.data) {
         toast.success(
           `Scan complete: ${json.data.matchedListings} new match${json.data.matchedListings !== 1 ? "es" : ""}`,
-          {
-            description: `Found ${json.data.listingsFound} listings, ${json.data.newListings} new`,
-          }
+          { description: `Found ${json.data.listingsFound} listings, ${json.data.newListings} new` }
         );
         onScanComplete?.();
       } else {
@@ -95,54 +137,133 @@ export function StatsBar({
   }
 
   return (
-    <div className="space-y-3">
-      {/* Wordmark + Scan button row */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight">
-          <span className="text-zinc-400">Hunt</span>
-          <span className="text-zinc-100">Your</span>
-          <span className="text-brand">Home</span>
-        </h1>
-        <button
-          onClick={handleScanNow}
-          disabled={scanning}
-          className="flex items-center gap-2 px-4 py-2 bg-brand hover:bg-brand-light disabled:opacity-60 disabled:cursor-not-allowed text-white text-sm font-semibold rounded-lg transition-colors"
-          aria-label="Run manual scan"
+    <div
+      className="rounded-none -mx-6 -mt-6 px-6 py-4 mb-6"
+      style={{ background: "#0D1117", borderBottom: "1px solid #21262D" }}
+    >
+      {/* Title row */}
+      <div className="flex items-center justify-between mb-4">
+        <h1
+          className="text-2xl font-semibold"
+          style={{ fontFamily: "var(--font-space-grotesk, sans-serif)" }}
         >
-          <RefreshCw
-            size={14}
-            className={scanning ? "animate-spin" : ""}
-          />
-          {scanning ? "Scanning..." : "Scan Now"}
-        </button>
+          <span style={{ color: "#8B949E" }}>Hunt</span>
+          <span style={{ color: "#E6EDF3", fontWeight: 700 }}>Your</span>
+          <span style={{ color: "#39D353" }}>Home</span>
+        </h1>
+
+        <div className="flex items-center gap-2">
+          {/* Mock toggle — dev only */}
+          {process.env.NEXT_PUBLIC_ENABLE_MOCK === "true" && onToggleMock && (
+            <button
+              onClick={onToggleMock}
+              className="flex items-center gap-1.5 rounded-lg text-xs font-semibold transition-all duration-150"
+              style={{
+                padding: "7px 12px",
+                fontFamily: "var(--font-inter, sans-serif)",
+                background: mockMode ? "rgba(57,211,83,0.12)" : "#161B22",
+                border: mockMode ? "1px solid rgba(57,211,83,0.35)" : "1px solid #30363D",
+                color: mockMode ? "#39D353" : "#8B949E",
+              }}
+              onMouseEnter={(e) => {
+                if (!mockMode) {
+                  (e.currentTarget as HTMLButtonElement).style.borderColor = "#484F58";
+                  (e.currentTarget as HTMLButtonElement).style.color = "#E6EDF3";
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (!mockMode) {
+                  (e.currentTarget as HTMLButtonElement).style.borderColor = "#30363D";
+                  (e.currentTarget as HTMLButtonElement).style.color = "#8B949E";
+                }
+              }}
+              aria-label={mockMode ? "Disable mock mode" : "Enable mock mode"}
+              title={mockMode ? "Mock mode ON — showing sample data" : "Mock mode OFF — showing live data"}
+            >
+              <FlaskConical size={13} />
+              Mock {mockMode ? "ON" : "OFF"}
+            </button>
+          )}
+
+          {/* Scan Now */}
+          <motion.button
+            onClick={handleScanNow}
+            disabled={scanning}
+            whileTap={{ scale: 0.96 }}
+            className={mockMode || scanning ? "flex items-center gap-1.5 rounded-lg text-sm font-semibold transition-all duration-150 opacity-40 cursor-not-allowed" : "btn-scan"}
+            style={mockMode || scanning ? {
+              background: "#161B22",
+              color: "#484F58",
+              padding: "8px 16px",
+              fontFamily: "var(--font-inter, sans-serif)",
+              border: "1px dashed #484F58",
+            } : { fontFamily: "var(--font-inter, sans-serif)" }}
+            title={mockMode ? "Disabled in mock mode" : scanning ? "Scan in progress..." : undefined}
+            aria-label="Run manual scan"
+          >
+            <Zap
+              size={14}
+              fill={scanning || mockMode ? "none" : "currentColor"}
+              className={scanning ? "animate-spin" : ""}
+            />
+            {scanning ? "Scanning..." : "Scan Now"}
+          </motion.button>
+        </div>
       </div>
 
-      {/* Stats */}
+      {/* Mock banner */}
+      {mockMode && (
+        <motion.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: "auto" }}
+          exit={{ opacity: 0, height: 0 }}
+          className="flex items-center gap-2 rounded-lg px-3 py-2 mb-4 text-xs"
+          style={{
+            background: "rgba(57,211,83,0.06)",
+            border: "1px solid rgba(57,211,83,0.4)",
+            color: "#8B949E",
+            fontFamily: "var(--font-inter, sans-serif)",
+            boxShadow: "inset 3px 0 0 0 #39D353",
+          }}
+        >
+          <FlaskConical size={12} style={{ color: "#39D353", flexShrink: 0 }} />
+          <span>
+            <span style={{ color: "#39D353", fontWeight: 600 }}>Mock mode enabled</span>
+            {" "}— displaying 5 sample Frisco TX listings (3bd/3ba+, under $650k). No real API calls are being made.
+          </span>
+        </motion.div>
+      )}
+
+      {/* Stat cards */}
       <div className="flex flex-wrap gap-3">
         <StatCard
           icon={Scan}
           label="Scans Today"
           value={todayScans}
+          isActive={todayScans > 0}
           delay={0}
         />
         <StatCard
           icon={Bell}
           label="New Matches"
           value={recentMatches}
-          accent={recentMatches > 0}
-          delay={0.05}
+          isActive={recentMatches > 0}
+          delay={0.07}
         />
         <StatCard
           icon={Clock}
           label="Last Scan"
-          value={lastScanLabel}
-          delay={0.1}
+          value={lastScanValue}
+          isActive={!lastScanIsNever}
+          italic={lastScanIsNever}
+          delay={0.14}
         />
         <StatCard
           icon={Database}
           label="Listings Seen"
           value={seenCount.toLocaleString()}
-          delay={0.15}
+          isActive={seenCount > 0}
+          delay={0.21}
         />
       </div>
     </div>

--- a/components/email/AlertEmailTemplate.tsx
+++ b/components/email/AlertEmailTemplate.tsx
@@ -84,7 +84,7 @@ export function AlertEmailTemplate({ listing, tier }: AlertEmailTemplateProps) {
           {/* Address & Price */}
           <Section style={styles.addressSection}>
             <Heading style={styles.address}>{listing.address}</Heading>
-            <Text style={styles.price}>
+            <Text style={{ ...styles.price, color: isHot ? "#39D353" : "#E6EDF3" }}>
               ${listing.price.toLocaleString()}
             </Text>
           </Section>
@@ -276,11 +276,12 @@ const styles: Record<string, React.CSSProperties> = {
     lineHeight: "1.3",
   },
   price: {
-    color: "#f97316",
-    fontSize: "28px",
-    fontWeight: "700",
+    color: "#E6EDF3",
+    fontSize: "32px",
+    fontWeight: "900",
+    fontFamily: "'Object Sans', 'Space Grotesk', Inter, sans-serif",
     margin: 0,
-    letterSpacing: "-0.5px",
+    letterSpacing: "-0.03em",
   },
   divider: {
     borderColor: "#27272a",
@@ -386,7 +387,7 @@ const styles: Record<string, React.CSSProperties> = {
     textAlign: "center" as const,
   },
   ctaButton: {
-    backgroundColor: "#f97316",
+    backgroundColor: "#006AFF",
     color: "#ffffff",
     padding: "14px 40px",
     borderRadius: "8px",

--- a/components/filters/BedsSelector.tsx
+++ b/components/filters/BedsSelector.tsx
@@ -7,36 +7,78 @@ interface BedsSelectorProps {
   options: Array<{ label: string; value: number }>;
 }
 
-export function BedsSelector({
-  label,
-  value,
-  onChange,
-  options,
-}: BedsSelectorProps) {
+export function BedsSelector({ label, value, onChange, options }: BedsSelectorProps) {
   return (
-    <div className="space-y-2">
+    <div className="space-y-2.5">
       <div className="flex items-center justify-between">
-        <span className="text-xs font-medium text-zinc-500 uppercase tracking-wide">
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            letterSpacing: "0.15em",
+            textTransform: "uppercase" as const,
+            color: "#484F58",
+            fontFamily: "var(--font-inter, sans-serif)",
+          }}
+        >
           {label}
         </span>
-        <span className="text-xs text-zinc-400">min</span>
+        <span
+          style={{
+            fontSize: 10,
+            color: "#484F58",
+            fontFamily: "var(--font-inter, sans-serif)",
+          }}
+        >
+          min
+        </span>
       </div>
       <div className="flex flex-wrap gap-1.5">
-        {options.map((opt) => (
-          <button
-            key={opt.value}
-            onClick={() => onChange(opt.value)}
-            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-              value === opt.value
-                ? "bg-brand text-white"
-                : "bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-200"
-            }`}
-            aria-label={`${label}: ${opt.label}`}
-            aria-pressed={value === opt.value}
-          >
-            {opt.label}
-          </button>
-        ))}
+        {options.map((opt) => {
+          const selected = value === opt.value;
+          return (
+            <button
+              key={opt.value}
+              onClick={() => onChange(opt.value)}
+              className="rounded-md transition-all duration-150"
+              style={{
+                padding: "6px 12px",
+                fontSize: 13,
+                fontFamily: "var(--font-inter, sans-serif)",
+                cursor: "pointer",
+                ...(selected
+                  ? {
+                      background: "#39D353",
+                      color: "#080C10",
+                      fontWeight: 600,
+                      border: "1px solid #39D353",
+                    }
+                  : {
+                      background: "#1C2430",
+                      color: "#8B949E",
+                      fontWeight: 400,
+                      border: "1px solid #21262D",
+                    }),
+              }}
+              onMouseEnter={(e) => {
+                if (!selected) {
+                  (e.currentTarget as HTMLButtonElement).style.borderColor = "#30363D";
+                  (e.currentTarget as HTMLButtonElement).style.color = "#E6EDF3";
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (!selected) {
+                  (e.currentTarget as HTMLButtonElement).style.borderColor = "#21262D";
+                  (e.currentTarget as HTMLButtonElement).style.color = "#8B949E";
+                }
+              }}
+              aria-label={`${label}: ${opt.label}`}
+              aria-pressed={selected}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/components/filters/FilterPanel.tsx
+++ b/components/filters/FilterPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { SlidersHorizontal, Save } from "lucide-react";
+import { Check } from "lucide-react";
 import { toast } from "sonner";
 import { UserPreferences, DEFAULT_PREFERENCES } from "@/lib/types";
 import { PriceRange } from "./PriceRange";
@@ -17,11 +17,11 @@ const BED_OPTIONS = [
 ];
 
 const BATH_OPTIONS = [
-  { label: "1+", value: 1 },
+  { label: "1+",   value: 1 },
   { label: "1.5+", value: 1.5 },
-  { label: "2+", value: 2 },
+  { label: "2+",   value: 2 },
   { label: "2.5+", value: 2.5 },
-  { label: "3+", value: 3 },
+  { label: "3+",   value: 3 },
 ];
 
 interface FilterPanelProps {
@@ -29,21 +29,50 @@ interface FilterPanelProps {
   onPrefsChange?: (prefs: UserPreferences) => void;
 }
 
+const SECTION_LABEL: React.CSSProperties = {
+  fontSize: 10,
+  fontWeight: 600,
+  letterSpacing: "0.15em",
+  textTransform: "uppercase" as const,
+  color: "#484F58",
+  fontFamily: "var(--font-inter, sans-serif)",
+  display: "block",
+  marginBottom: 10,
+};
+
+const INPUT: React.CSSProperties = {
+  width: "100%",
+  background: "#0D1117",
+  border: "1px solid #21262D",
+  borderRadius: 8,
+  padding: "8px 12px",
+  fontSize: 14,
+  color: "#E6EDF3",
+  fontFamily: "var(--font-inter, sans-serif)",
+  outline: "none",
+  transition: "border-color 0.15s, box-shadow 0.15s",
+};
+
+const DIVIDER: React.CSSProperties = {
+  borderBottom: "1px solid #21262D",
+  marginBottom: 20,
+  paddingBottom: 20,
+};
+
 export function FilterPanel({ initialPrefs, onPrefsChange }: FilterPanelProps) {
-  const [prefs, setPrefs] = useState<UserPreferences>(
-    initialPrefs ?? DEFAULT_PREFERENCES
-  );
+  const [prefs, setPrefs] = useState<UserPreferences>(initialPrefs ?? DEFAULT_PREFERENCES);
   const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isFirstMount = useRef(true);
 
-  // Update from parent
   useEffect(() => {
     if (initialPrefs) setPrefs(initialPrefs);
   }, [initialPrefs]);
 
   const savePrefs = useCallback(async (newPrefs: UserPreferences) => {
     setSaving(true);
+    setSaved(false);
     try {
       const res = await fetch("/api/preferences", {
         method: "POST",
@@ -53,6 +82,8 @@ export function FilterPanel({ initialPrefs, onPrefsChange }: FilterPanelProps) {
       const json = await res.json() as { success: boolean };
       if (json.success) {
         toast.success("Preferences saved");
+        setSaved(true);
+        setTimeout(() => setSaved(false), 2000);
         onPrefsChange?.(newPrefs);
       } else {
         toast.error("Failed to save preferences");
@@ -67,113 +98,132 @@ export function FilterPanel({ initialPrefs, onPrefsChange }: FilterPanelProps) {
   function updatePrefs(updates: Partial<UserPreferences>) {
     const next = { ...prefs, ...updates };
     setPrefs(next);
-
-    // Debounce auto-save
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      void savePrefs(next);
-    }, 500);
+    debounceRef.current = setTimeout(() => { void savePrefs(next); }, 500);
   }
 
-  // Don't auto-save on first mount
   useEffect(() => {
-    if (isFirstMount.current) {
-      isFirstMount.current = false;
-      return;
-    }
+    if (isFirstMount.current) { isFirstMount.current = false; }
   }, []);
+
+  function focusInput(e: React.FocusEvent<HTMLInputElement>) {
+    e.target.style.borderColor = "#39D353";
+    e.target.style.boxShadow = "0 0 0 1px rgba(57,211,83,0.3)";
+  }
+  function blurInput(e: React.FocusEvent<HTMLInputElement>) {
+    e.target.style.borderColor = "#21262D";
+    e.target.style.boxShadow = "none";
+  }
 
   return (
     <aside
-      className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 space-y-6"
+      className="rounded-xl custom-scrollbar"
+      style={{
+        background: "#161B22",
+        border: "1px solid #21262D",
+        padding: 20,
+        maxHeight: "calc(100vh - 120px)",
+        overflowY: "auto",
+      }}
       aria-label="Search criteria"
     >
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <div className="flex items-center gap-2">
-            <SlidersHorizontal size={15} className="text-zinc-500" />
-            <h2 className="text-zinc-100 font-semibold text-sm">Search Criteria</h2>
-          </div>
-          <p className="text-[11px] text-zinc-600 mt-0.5 ml-5">
-            Changes save automatically
-          </p>
+      {/* Panel header */}
+      <div className="flex items-start justify-between mb-1">
+        <div className="flex items-center gap-2">
+          <div className="w-1 h-5 rounded-full" style={{ background: "#39D353" }} />
+          <h2
+            className="font-semibold text-base"
+            style={{ color: "#E6EDF3", fontFamily: "var(--font-space-grotesk, sans-serif)" }}
+          >
+            Search Criteria
+          </h2>
         </div>
-        {saving && (
-          <div className="flex items-center gap-1.5 text-xs text-zinc-500">
-            <Save size={11} className="animate-pulse" />
-            Saving…
-          </div>
-        )}
+        <div className="h-6 flex items-center mt-0.5">
+          {saving && (
+            <span className="text-[11px] flex items-center gap-1" style={{ color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}>
+              <span className="w-1 h-1 rounded-full animate-pulse" style={{ background: "#39D353" }} />
+              saving…
+            </span>
+          )}
+          {saved && !saving && (
+            <span className="flex items-center gap-1 text-[11px]" style={{ color: "#39D353", fontFamily: "var(--font-inter, sans-serif)" }}>
+              <Check size={11} /> saved
+            </span>
+          )}
+        </div>
       </div>
+      <p className="ml-3 mb-5" style={{ fontSize: 11, color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}>
+        changes save automatically
+      </p>
+      <div style={{ borderTop: "1px solid #21262D", marginBottom: 20 }} />
 
       {/* Price Range */}
-      <PriceRange
-        minPrice={prefs.minPrice}
-        maxPrice={prefs.maxPrice}
-        onMinChange={(val) => updatePrefs({ minPrice: val })}
-        onMaxChange={(val) => updatePrefs({ maxPrice: val })}
-      />
+      <div style={DIVIDER}>
+        <PriceRange
+          minPrice={prefs.minPrice}
+          maxPrice={prefs.maxPrice}
+          onMinChange={(val) => updatePrefs({ minPrice: val })}
+          onMaxChange={(val) => updatePrefs({ maxPrice: val })}
+        />
+      </div>
 
       {/* Beds */}
-      <BedsSelector
-        label="Bedrooms"
-        value={prefs.minBeds}
-        onChange={(val) => updatePrefs({ minBeds: val })}
-        options={BED_OPTIONS}
-      />
+      <div style={DIVIDER}>
+        <BedsSelector
+          label="Bedrooms"
+          value={prefs.minBeds}
+          onChange={(val) => updatePrefs({ minBeds: val })}
+          options={BED_OPTIONS}
+        />
+      </div>
 
       {/* Baths */}
-      <BedsSelector
-        label="Bathrooms"
-        value={prefs.minBaths}
-        onChange={(val) => updatePrefs({ minBaths: val })}
-        options={BATH_OPTIONS}
-      />
+      <div style={DIVIDER}>
+        <BedsSelector
+          label="Bathrooms"
+          value={prefs.minBaths}
+          onChange={(val) => updatePrefs({ minBaths: val })}
+          options={BATH_OPTIONS}
+        />
+      </div>
 
       {/* Min Sqft */}
-      <div className="space-y-2">
-        <span className="text-xs font-medium text-zinc-500 uppercase tracking-wide block">
-          Min Square Feet
-        </span>
+      <div style={DIVIDER}>
+        <span style={SECTION_LABEL}>Min Square Feet</span>
         <div className="flex items-center gap-2">
           <button
-            onClick={() =>
-              updatePrefs({ minSqft: Math.max(0, prefs.minSqft - 100) })
-            }
-            className="w-8 h-8 rounded-lg bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-lg font-medium transition-colors"
+            onClick={() => updatePrefs({ minSqft: Math.max(0, prefs.minSqft - 100) })}
+            style={{ width: 32, height: 32, background: "#1C2430", border: "1px solid #21262D", borderRadius: 8, color: "#8B949E", fontSize: 16, cursor: "pointer", transition: "border-color 150ms" }}
+            onMouseEnter={(e) => ((e.currentTarget as HTMLButtonElement).style.borderColor = "#30363D")}
+            onMouseLeave={(e) => ((e.currentTarget as HTMLButtonElement).style.borderColor = "#21262D")}
             aria-label="Decrease min sqft"
-          >
-            −
-          </button>
+          >−</button>
           <input
             type="number"
             value={prefs.minSqft}
             min={0}
             step={100}
-            onChange={(e) =>
-              updatePrefs({ minSqft: Math.max(0, Number(e.target.value)) })
-            }
-            className="flex-1 bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-center text-sm font-medium text-zinc-100 focus:outline-none focus:border-brand"
+            onChange={(e) => updatePrefs({ minSqft: Math.max(0, Number(e.target.value)) })}
+            style={{ ...INPUT, textAlign: "center" }}
+            onFocus={focusInput}
+            onBlur={blurInput}
             aria-label="Minimum square feet"
           />
           <button
             onClick={() => updatePrefs({ minSqft: prefs.minSqft + 100 })}
-            className="w-8 h-8 rounded-lg bg-zinc-800 hover:bg-zinc-700 text-zinc-300 text-lg font-medium transition-colors"
+            style={{ width: 32, height: 32, background: "#1C2430", border: "1px solid #21262D", borderRadius: 8, color: "#8B949E", fontSize: 16, cursor: "pointer", transition: "border-color 150ms" }}
+            onMouseEnter={(e) => ((e.currentTarget as HTMLButtonElement).style.borderColor = "#30363D")}
+            onMouseLeave={(e) => ((e.currentTarget as HTMLButtonElement).style.borderColor = "#21262D")}
             aria-label="Increase min sqft"
-          >
-            +
-          </button>
+          >+</button>
         </div>
       </div>
 
       {/* Min Year Built */}
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <span className="text-xs font-medium text-zinc-500 uppercase tracking-wide">
-            Min Year Built
-          </span>
-          <span className="text-sm font-semibold text-zinc-100">
+      <div style={DIVIDER}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 10 }}>
+          <span style={SECTION_LABEL}>Min Year Built</span>
+          <span style={{ fontSize: 14, fontWeight: 700, color: "#39D353", fontFamily: "var(--font-mono, monospace)" }}>
             {prefs.minYearBuilt}
           </span>
         </div>
@@ -183,20 +233,18 @@ export function FilterPanel({ initialPrefs, onPrefsChange }: FilterPanelProps) {
           max={2020}
           step={1}
           value={prefs.minYearBuilt}
-          onChange={(e) =>
-            updatePrefs({ minYearBuilt: Number(e.target.value) })
-          }
-          className="w-full"
+          onChange={(e) => updatePrefs({ minYearBuilt: Number(e.target.value) })}
+          className="custom-slider w-full"
           aria-label="Minimum year built"
         />
-        <div className="flex justify-between text-[10px] text-zinc-600">
+        <div className="flex justify-between mt-1.5" style={{ fontSize: 10, color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}>
           <span>1970</span>
           <span>2020</span>
         </div>
       </div>
 
       {/* Max HOA */}
-      <div className="space-y-3">
+      <div style={DIVIDER}>
         <ToggleFilter
           label="Max HOA Limit"
           description="Filter by monthly HOA fee"
@@ -204,80 +252,60 @@ export function FilterPanel({ initialPrefs, onPrefsChange }: FilterPanelProps) {
           onChange={(val) => updatePrefs({ maxHoa: val ? 200 : null })}
         />
         {prefs.maxHoa !== null && (
-          <div className="flex items-center gap-2 ml-0">
-            <span className="text-xs text-zinc-600">$</span>
+          <div className="flex items-center gap-2 mt-3">
+            <span style={{ fontSize: 12, color: "#484F58" }}>$</span>
             <input
               type="number"
               value={prefs.maxHoa}
               min={0}
               step={25}
-              onChange={(e) =>
-                updatePrefs({ maxHoa: Math.max(0, Number(e.target.value)) })
-              }
-              className="flex-1 bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:border-brand"
+              onChange={(e) => updatePrefs({ maxHoa: Math.max(0, Number(e.target.value)) })}
+              style={INPUT}
+              onFocus={focusInput}
+              onBlur={blurInput}
               aria-label="Maximum HOA per month"
             />
-            <span className="text-xs text-zinc-600">/mo</span>
+            <span style={{ fontSize: 12, color: "#484F58" }}>/mo</span>
           </div>
         )}
       </div>
 
       {/* AI Score Threshold */}
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <span className="text-xs font-medium text-zinc-500 uppercase tracking-wide">
-            AI Score Threshold
-          </span>
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-zinc-600">Min</span>
-            <span className="text-sm font-bold text-brand">
-              {prefs.scoreThreshold}
-            </span>
-            <span className="text-xs text-zinc-600">Hot ≥</span>
-            <span className="text-sm font-bold text-brand">
-              {prefs.hotScoreThreshold}
-            </span>
+      <div style={DIVIDER}>
+        <div className="flex items-center justify-between" style={{ marginBottom: 10 }}>
+          <span style={SECTION_LABEL}>AI Score Threshold</span>
+          <div className="flex items-center gap-2" style={{ fontFamily: "var(--font-mono, monospace)", fontSize: 13 }}>
+            <span style={{ color: "#484F58" }}>min</span>
+            <span style={{ color: "#39D353", fontWeight: 700 }}>{prefs.scoreThreshold}</span>
+            <span style={{ color: "#484F58" }}>hot≥</span>
+            <span style={{ color: "#39D353", fontWeight: 700 }}>{prefs.hotScoreThreshold}</span>
           </div>
         </div>
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <span className="text-xs text-zinc-600 w-8">Alert</span>
+            <span style={{ fontSize: 10, color: "#484F58", width: 30, fontFamily: "var(--font-inter, sans-serif)" }}>alert</span>
             <input
               type="range"
-              min={1}
-              max={10}
-              step={1}
+              min={1} max={10} step={1}
               value={prefs.scoreThreshold}
-              onChange={(e) =>
-                updatePrefs({
-                  scoreThreshold: Number(e.target.value),
-                  hotScoreThreshold: Math.max(
-                    Number(e.target.value) + 1,
-                    prefs.hotScoreThreshold
-                  ),
-                })
-              }
-              className="flex-1"
+              onChange={(e) => updatePrefs({
+                scoreThreshold: Number(e.target.value),
+                hotScoreThreshold: Math.max(Number(e.target.value) + 1, prefs.hotScoreThreshold),
+              })}
+              className="custom-slider flex-1"
               aria-label="Minimum AI score to alert"
             />
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-xs text-zinc-600 w-8">Hot</span>
+            <span style={{ fontSize: 10, color: "#484F58", width: 30, fontFamily: "var(--font-inter, sans-serif)" }}>hot</span>
             <input
               type="range"
-              min={1}
-              max={10}
-              step={1}
+              min={1} max={10} step={1}
               value={prefs.hotScoreThreshold}
-              onChange={(e) =>
-                updatePrefs({
-                  hotScoreThreshold: Math.max(
-                    Number(e.target.value),
-                    prefs.scoreThreshold + 1
-                  ),
-                })
-              }
-              className="flex-1"
+              onChange={(e) => updatePrefs({
+                hotScoreThreshold: Math.max(Number(e.target.value), prefs.scoreThreshold + 1),
+              })}
+              className="custom-slider flex-1"
               aria-label="Minimum AI score for HOT alert"
             />
           </div>
@@ -285,41 +313,46 @@ export function FilterPanel({ initialPrefs, onPrefsChange }: FilterPanelProps) {
       </div>
 
       {/* Require Garage */}
-      <ToggleFilter
-        label="Require Garage"
-        description="Only show listings with garage"
-        checked={prefs.requireGarage}
-        onChange={(val) => updatePrefs({ requireGarage: val })}
-      />
+      <div style={DIVIDER}>
+        <ToggleFilter
+          label="Require Garage"
+          description="Only show listings with garage"
+          checked={prefs.requireGarage}
+          onChange={(val) => updatePrefs({ requireGarage: val })}
+        />
+      </div>
 
       {/* Alert Email */}
-      <div className="space-y-2">
-        <span className="text-xs font-medium text-zinc-500 uppercase tracking-wide block">
-          Alert Email
-        </span>
+      <div style={DIVIDER}>
+        <span style={SECTION_LABEL}>Alert Email</span>
         <input
           type="email"
           value={prefs.alertEmail}
           placeholder="your@email.com"
           onChange={(e) => updatePrefs({ alertEmail: e.target.value })}
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-brand"
+          style={{ ...INPUT, color: prefs.alertEmail ? "#E6EDF3" : "#484F58" }}
+          onFocus={focusInput}
+          onBlur={blurInput}
           aria-label="Alert email address"
         />
       </div>
 
       {/* Search Area */}
-      <div className="space-y-2">
-        <span className="text-xs font-medium text-zinc-500 uppercase tracking-wide block">
-          Search Area
-        </span>
+      <div>
+        <span style={SECTION_LABEL}>Search Area</span>
         <input
           type="text"
           value={prefs.searchArea}
           placeholder="Frisco, TX"
           onChange={(e) => updatePrefs({ searchArea: e.target.value })}
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-brand"
+          style={INPUT}
+          onFocus={focusInput}
+          onBlur={blurInput}
           aria-label="Search area"
         />
+        <p className="mt-1.5" style={{ fontSize: 11, color: "#484F58", fontFamily: "var(--font-inter, sans-serif)" }}>
+          Limited to Zillow search areas
+        </p>
       </div>
     </aside>
   );

--- a/components/filters/PriceRange.tsx
+++ b/components/filters/PriceRange.tsx
@@ -19,12 +19,7 @@ const MIN = 0;
 const MAX = 2000000;
 const STEP = 25000;
 
-export function PriceRange({
-  minPrice,
-  maxPrice,
-  onMinChange,
-  onMaxChange,
-}: PriceRangeProps) {
+export function PriceRange({ minPrice, maxPrice, onMinChange, onMaxChange }: PriceRangeProps) {
   const [localMin, setLocalMin] = useState(minPrice);
   const [localMax, setLocalMax] = useState(maxPrice);
 
@@ -43,17 +38,42 @@ export function PriceRange({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <span className="text-xs font-medium text-zinc-500 uppercase tracking-wide">
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            letterSpacing: "0.15em",
+            textTransform: "uppercase" as const,
+            color: "#484F58",
+            fontFamily: "var(--font-inter, sans-serif)",
+          }}
+        >
           Price Range
         </span>
-        <span className="text-sm font-semibold text-zinc-100">
+        <span
+          style={{
+            fontSize: 13,
+            fontWeight: 600,
+            color: "#39D353",
+            fontFamily: "var(--font-mono, monospace)",
+          }}
+        >
           {formatPrice(localMin)} — {formatPrice(localMax)}
         </span>
       </div>
 
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <span className="text-xs text-zinc-600 w-6">Min</span>
+          <span
+            style={{
+              fontSize: 10,
+              color: "#484F58",
+              width: 24,
+              fontFamily: "var(--font-inter, sans-serif)",
+            }}
+          >
+            min
+          </span>
           <input
             type="range"
             min={MIN}
@@ -61,12 +81,21 @@ export function PriceRange({
             step={STEP}
             value={localMin}
             onChange={(e) => handleMinChange(Number(e.target.value))}
-            className="flex-1"
+            className="custom-slider flex-1"
             aria-label="Minimum price"
           />
         </div>
         <div className="flex items-center gap-2">
-          <span className="text-xs text-zinc-600 w-6">Max</span>
+          <span
+            style={{
+              fontSize: 10,
+              color: "#484F58",
+              width: 24,
+              fontFamily: "var(--font-inter, sans-serif)",
+            }}
+          >
+            max
+          </span>
           <input
             type="range"
             min={MIN}
@@ -74,7 +103,7 @@ export function PriceRange({
             step={STEP}
             value={localMax}
             onChange={(e) => handleMaxChange(Number(e.target.value))}
-            className="flex-1"
+            className="custom-slider flex-1"
             aria-label="Maximum price"
           />
         </div>

--- a/components/filters/ToggleFilter.tsx
+++ b/components/filters/ToggleFilter.tsx
@@ -7,33 +7,56 @@ interface ToggleFilterProps {
   description?: string;
 }
 
-export function ToggleFilter({
-  label,
-  checked,
-  onChange,
-  description,
-}: ToggleFilterProps) {
+export function ToggleFilter({ label, checked, onChange, description }: ToggleFilterProps) {
   return (
     <div className="flex items-center justify-between gap-3">
       <div>
-        <div className="text-sm font-medium text-zinc-300">{label}</div>
+        <div
+          className="text-sm"
+          style={{
+            color: "#E6EDF3",
+            fontFamily: "var(--font-inter, sans-serif)",
+          }}
+        >
+          {label}
+        </div>
         {description && (
-          <div className="text-xs text-zinc-600 mt-0.5">{description}</div>
+          <div
+            className="mt-0.5"
+            style={{
+              fontSize: 11,
+              color: "#484F58",
+              fontFamily: "var(--font-inter, sans-serif)",
+            }}
+          >
+            {description}
+          </div>
         )}
       </div>
+
       <button
         role="switch"
         aria-checked={checked}
         aria-label={label}
         onClick={() => onChange(!checked)}
-        className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 ${
-          checked ? "bg-brand" : "bg-zinc-700"
-        }`}
+        className="relative inline-flex shrink-0 cursor-pointer rounded-full transition-all duration-200 focus-visible:outline-none"
+        style={{
+          width: 36,
+          height: 20,
+          padding: 2,
+          background: checked ? "#1A7F37" : "#30363D",
+          border: checked ? "1px solid rgba(57,211,83,0.3)" : "1px solid #484F58",
+          boxShadow: checked ? "0 0 8px rgba(57,211,83,0.2)" : "none",
+        }}
       >
         <span
-          className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-lg transform transition duration-200 ${
-            checked ? "translate-x-4" : "translate-x-0"
-          }`}
+          className="inline-block rounded-full shadow transition-all duration-200"
+          style={{
+            width: 14,
+            height: 14,
+            background: checked ? "#39D353" : "#8B949E",
+            transform: checked ? "translateX(16px)" : "translateX(0px)",
+          }}
         />
       </button>
     </div>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -8,28 +8,47 @@ interface HeaderProps {
 
 export function Header({ onMenuClick }: HeaderProps) {
   return (
-    <header className="sticky top-0 z-20 flex items-center justify-between px-4 py-3 bg-onyx-950/80 backdrop-blur border-b border-zinc-800 lg:hidden">
+    <header
+      className="sticky top-0 z-20 flex items-center justify-between px-4 py-3 backdrop-blur lg:hidden"
+      style={{ background: "rgba(13,17,23,0.9)", borderBottom: "1px solid #21262D" }}
+    >
       <button
         onClick={onMenuClick}
-        className="p-2 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 transition-colors"
+        className="p-2 rounded-md transition-colors"
+        style={{ color: "#8B949E" }}
+        onMouseEnter={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.background = "#1C2430";
+          (e.currentTarget as HTMLButtonElement).style.color = "#E6EDF3";
+        }}
+        onMouseLeave={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+          (e.currentTarget as HTMLButtonElement).style.color = "#8B949E";
+        }}
         aria-label="Open menu"
       >
         <Menu size={20} />
       </button>
 
-      <div className="flex items-center gap-1.5">
-        <div className="w-6 h-6 rounded-md bg-brand flex items-center justify-center">
-          <span className="text-white font-bold text-xs">H</span>
-        </div>
-        <span className="text-sm font-semibold">
-          <span className="text-zinc-400">Hunt</span>
-          <span className="text-zinc-100">Your</span>
-          <span className="text-brand">Home</span>
-        </span>
-      </div>
+      <span
+        className="text-sm font-semibold"
+        style={{ fontFamily: "var(--font-space-grotesk, sans-serif)" }}
+      >
+        <span style={{ color: "#8B949E" }}>Hunt</span>
+        <span style={{ color: "#E6EDF3", fontWeight: 700 }}>Your</span>
+        <span style={{ color: "#39D353" }}>Home</span>
+      </span>
 
       <button
-        className="p-2 rounded-lg text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 transition-colors"
+        className="p-2 rounded-md transition-colors"
+        style={{ color: "#8B949E" }}
+        onMouseEnter={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.background = "#1C2430";
+          (e.currentTarget as HTMLButtonElement).style.color = "#E6EDF3";
+        }}
+        onMouseLeave={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+          (e.currentTarget as HTMLButtonElement).style.color = "#8B949E";
+        }}
         aria-label="Notifications"
       >
         <Bell size={20} />

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,68 +1,125 @@
 "use client";
 
-import { Home, Bell, Settings, Activity, ChevronRight } from "lucide-react";
+import { Home, Bell, Settings, Activity, Bookmark } from "lucide-react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { motion } from "framer-motion";
 
 const navItems = [
-  { icon: Home, label: "Dashboard", href: "/", active: true },
-  { icon: Bell, label: "Alerts", href: "#alerts" },
-  { icon: Activity, label: "Scan History", href: "#history" },
-  { icon: Settings, label: "Settings", href: "#settings" },
+  { icon: Home,     label: "Dashboard",    href: "/" },
+  { icon: Bell,     label: "Alerts",       href: "/alerts" },
+  { icon: Bookmark, label: "Bookmarks",    href: "/bookmarks" },
+  { icon: Activity, label: "Scan History", href: "/history" },
+  { icon: Settings, label: "Settings",     href: "/settings" },
 ];
 
 export function Sidebar() {
+  const pathname = usePathname();
+
   return (
-    <aside className="hidden lg:flex flex-col w-56 min-h-screen bg-zinc-900 border-r border-zinc-800 fixed left-0 top-0 z-30">
+    <aside
+      className="hidden lg:flex flex-col w-[220px] min-h-screen fixed left-0 top-0 z-30"
+      style={{ background: "#0D1117", borderRight: "1px solid #21262D" }}
+    >
       {/* Logo */}
-      <div className="px-5 py-6 border-b border-zinc-800">
-        <div className="flex items-center gap-2">
-          <div className="w-8 h-8 rounded-lg bg-brand flex items-center justify-center">
-            <span className="text-white font-bold text-sm">H</span>
-          </div>
-          <div className="leading-tight">
-            <div className="text-xs font-semibold">
-              <span className="text-zinc-400">Hunt</span>
-              <span className="text-zinc-100">Your</span>
-              <span className="text-brand">Home</span>
-            </div>
-            <div className="text-[10px] text-zinc-600">Frisco, TX Monitor</div>
-          </div>
+      <div
+        className="flex items-center gap-2.5 px-4"
+        style={{ height: 64, borderBottom: "1px solid #21262D" }}
+      >
+        <div
+          className="w-7 h-7 rounded-md flex items-center justify-center shrink-0"
+          style={{ background: "#39D353" }}
+        >
+          <span
+            className="text-xs font-bold"
+            style={{ color: "#080C10", fontFamily: "var(--font-space-grotesk, sans-serif)" }}
+          >
+            H
+          </span>
         </div>
+        <Link
+          href="/"
+          className="text-sm font-semibold"
+          style={{ fontFamily: "var(--font-space-grotesk, sans-serif)", textDecoration: "none" }}
+        >
+          <span style={{ color: "#8B949E" }}>Hunt</span>
+          <span style={{ color: "#E6EDF3", fontWeight: 700 }}>Your</span>
+          <span style={{ color: "#39D353" }}>Home</span>
+        </Link>
       </div>
 
       {/* Nav */}
-      <nav className="flex-1 px-3 py-4 space-y-1">
-        {navItems.map((item) => (
-          <Link
-            key={item.label}
-            href={item.href}
-            className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors group ${
-              item.active
-                ? "bg-brand/10 text-brand border border-brand/20"
-                : "text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800"
-            }`}
-          >
-            <item.icon
-              size={16}
-              className={
-                item.active
-                  ? "text-brand"
-                  : "text-zinc-500 group-hover:text-zinc-300"
-              }
-            />
-            {item.label}
-            {item.active && (
-              <ChevronRight size={12} className="ml-auto text-brand/60" />
-            )}
-          </Link>
-        ))}
+      <nav className="flex-1 px-2 py-4 space-y-0.5">
+        {navItems.map((item, i) => {
+          const active = pathname === item.href;
+          return (
+            <motion.div
+              key={item.label}
+              initial={{ opacity: 0, x: -6 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: i * 0.055, duration: 0.2 }}
+            >
+              <Link
+                href={item.href}
+                className="flex items-center gap-2.5 py-2 rounded-md text-sm transition-colors duration-150"
+                style={
+                  active
+                    ? {
+                        color: "#E6EDF3",
+                        background: "transparent",
+                        borderLeft: "2px solid #39D353",
+                        paddingLeft: "calc(0.75rem - 2px)",
+                        paddingRight: "0.75rem",
+                      }
+                    : {
+                        color: "#8B949E",
+                        borderLeft: "2px solid transparent",
+                        paddingLeft: "calc(0.75rem - 2px)",
+                        paddingRight: "0.75rem",
+                      }
+                }
+                onMouseEnter={(e) => {
+                  if (!active) {
+                    (e.currentTarget as HTMLAnchorElement).style.background = "rgba(28,36,48,0.5)";
+                    (e.currentTarget as HTMLAnchorElement).style.color = "#E6EDF3";
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (!active) {
+                    (e.currentTarget as HTMLAnchorElement).style.background = "transparent";
+                    (e.currentTarget as HTMLAnchorElement).style.color = "#8B949E";
+                  }
+                }}
+              >
+                <item.icon
+                  size={16}
+                  style={{ color: active ? "#39D353" : "#484F58" }}
+                />
+                <span style={{ fontFamily: "var(--font-inter, sans-serif)", fontSize: 14 }}>
+                  {item.label}
+                </span>
+              </Link>
+            </motion.div>
+          );
+        })}
       </nav>
 
-      {/* Footer */}
-      <div className="px-5 py-4 border-t border-zinc-800">
-        <div className="flex items-center gap-2">
-          <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-          <span className="text-xs text-zinc-500">Agent active</span>
+      {/* Status pill */}
+      <div className="px-4 py-5">
+        <div
+          className="inline-flex items-center gap-2 rounded-full px-3 py-1"
+          style={{ background: "#161B22" }}
+        >
+          <span
+            className="w-1.5 h-1.5 rounded-full animate-pulse"
+            style={{ background: "#39D353", boxShadow: "0 0 4px #39D353" }}
+          />
+          <span
+            className="text-[11px]"
+            style={{ color: "#8B949E", fontFamily: "var(--font-inter, sans-serif)" }}
+          >
+            agent active
+          </span>
         </div>
       </div>
     </aside>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import * as React from "react"
+import { Slider as SliderPrimitive } from "@base-ui/react/slider"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: SliderPrimitive.Root.Props) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  )
+
+  return (
+    <SliderPrimitive.Root
+      className={cn("data-horizontal:w-full data-vertical:h-full", className)}
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      thumbAlignment="edge"
+      {...props}
+    >
+      <SliderPrimitive.Control className="relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:min-h-40 data-vertical:w-auto data-vertical:flex-col">
+        <SliderPrimitive.Track
+          data-slot="slider-track"
+          className="relative grow overflow-hidden rounded-full bg-muted select-none data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1"
+        >
+          <SliderPrimitive.Indicator
+            data-slot="slider-range"
+            className="bg-primary select-none data-horizontal:h-full data-vertical:w-full"
+          />
+        </SliderPrimitive.Track>
+        {Array.from({ length: _values.length }, (_, index) => (
+          <SliderPrimitive.Thumb
+            data-slot="slider-thumb"
+            key={index}
+            className="relative block size-3 shrink-0 rounded-full border border-ring bg-white ring-ring/50 transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-3 focus-visible:ring-3 focus-visible:outline-hidden active:ring-3 disabled:pointer-events-none disabled:opacity-50"
+          />
+        ))}
+      </SliderPrimitive.Control>
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1 has-data-[icon=inline-start]:pl-1 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/lib/cookie-prefs.ts
+++ b/lib/cookie-prefs.ts
@@ -1,0 +1,39 @@
+import { UserPreferences, DEFAULT_PREFERENCES } from "./types";
+
+const COOKIE_NAME = "hyh_preferences";
+const COOKIE_DAYS = 30;
+
+export function savePrefsToookie(prefs: UserPreferences): void {
+  if (typeof document === "undefined") return;
+  const expires = new Date();
+  expires.setDate(expires.getDate() + COOKIE_DAYS);
+  document.cookie = [
+    `${COOKIE_NAME}=${encodeURIComponent(JSON.stringify(prefs))}`,
+    `expires=${expires.toUTCString()}`,
+    "path=/",
+    "SameSite=Lax",
+  ].join("; ");
+}
+
+export function getPrefsFromCookie(): UserPreferences | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    new RegExp(`(?:^|;\\s*)${COOKIE_NAME}=([^;]*)`)
+  );
+  if (!match) return null;
+  try {
+    return JSON.parse(decodeURIComponent(match[1])) as UserPreferences;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPrefsCookie(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/`;
+}
+
+/** Merge cookie prefs on top of defaults — cookie wins for any key present */
+export function mergeWithDefaults(partial: Partial<UserPreferences>): UserPreferences {
+  return { ...DEFAULT_PREFERENCES, ...partial };
+}

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -2,7 +2,11 @@ import { Resend } from "resend";
 import { AIScoredListing } from "./types";
 import { AlertEmailTemplate } from "@/components/email/AlertEmailTemplate";
 
-const resend = new Resend(process.env.RESEND_API_KEY);
+function getResend(): Resend {
+  const key = process.env.RESEND_API_KEY;
+  if (!key) throw new Error("RESEND_API_KEY is not set");
+  return new Resend(key);
+}
 
 const FROM = process.env.ALERT_EMAIL_FROM ?? "HuntYourHome <alerts@huntyourhome.app>";
 
@@ -11,6 +15,7 @@ export async function sendHotAlert(
   to: string
 ): Promise<boolean> {
   try {
+    const resend = getResend();
     const { error } = await resend.emails.send({
       from: FROM,
       to,
@@ -36,6 +41,7 @@ export async function sendMatchDigest(
 
   try {
     // Send individual emails for each MATCH listing
+    const resend = getResend();
     const results = await Promise.all(
       listings.map((listing) =>
         resend.emails.send({

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -1,0 +1,284 @@
+import { AlertRecord, ScanRecord } from "./types";
+
+// ─── 5 real Frisco TX listings, 3bd/3ba+, under $650k ────────────────────────
+// Photos: Unsplash residential/suburban exteriors
+
+export const MOCK_ALERTS: AlertRecord[] = [
+  {
+    id: "mock-001",
+    emailDelivered: true,
+    sentAt: new Date(Date.now() - 18 * 60 * 1000).toISOString(), // 18 min ago
+    listing: {
+      id: "zpid-99124001",
+      address: "9124 Saddleridge Dr, Frisco, TX 75035",
+      price: 589000,
+      beds: 4,
+      baths: 3,
+      sqft: 2480,
+      yearBuilt: 2017,
+      lotSizeSqft: 7200,
+      hoaMonthly: 125,
+      daysOnMarket: 8,
+      listingType: "FOR_SALE",
+      pricePerSqft: 237,
+      zillowUrl: "https://www.zillow.com/homes/frisco-tx_rb/",
+      photos: [
+        "https://images.unsplash.com/photo-1564013799919-ab600027ffc6?w=800&q=80",
+      ],
+      description:
+        "Stunning 4-bed home in coveted Plantation Resort. Open-concept kitchen with quartz counters, stainless appliances, and oversized island. Primary suite has spa-like bath. Extended back patio perfect for entertaining. 3-car garage.",
+      latitude: 33.1581,
+      longitude: -96.8236,
+      // AI fields
+      aiScore: 9,
+      alertTier: "HOT",
+      aiReason:
+        "Exceptional value in Plantation Resort — $237/sqft is well below the Frisco median for this subdivision. Only 8 days on market with a 3-car garage is rare under $600k.",
+      aiHighlights: [
+        "3-car garage — rare under $600k in Frisco",
+        "$237/sqft — 12% below neighborhood median",
+        "Corner lot with 7,200 sqft — larger than typical",
+      ],
+      aiConcerns: ["HOA at $125/mo adds ~$1,500/yr to carrying cost"],
+    },
+  },
+  {
+    id: "mock-002",
+    emailDelivered: true,
+    sentAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hrs ago
+    listing: {
+      id: "zpid-99124002",
+      address: "6703 Mockingbird Ln, Frisco, TX 75034",
+      price: 515000,
+      beds: 3,
+      baths: 3,
+      sqft: 2150,
+      yearBuilt: 2015,
+      lotSizeSqft: 6100,
+      hoaMonthly: 85,
+      daysOnMarket: 3,
+      listingType: "FOR_SALE",
+      pricePerSqft: 239,
+      zillowUrl: "https://www.zillow.com/homes/frisco-tx_rb/",
+      photos: [
+        "https://images.unsplash.com/photo-1570129477492-45c003edd2be?w=800&q=80",
+      ],
+      description:
+        "Move-in ready gem in Starwood. Freshly painted interior, updated kitchen with new hardware, and hand-scraped hardwood floors throughout main level. Private backyard with mature oaks. Walk to top-rated Frisco ISD schools.",
+      latitude: 33.1502,
+      longitude: -96.8451,
+      aiScore: 8,
+      alertTier: "HOT",
+      aiReason:
+        "Only 3 days on market at a strong price point for Starwood. Updated finishes and Frisco ISD proximity make this a fast mover — similar comps went under contract in under 7 days.",
+      aiHighlights: [
+        "3 DOM — likely to go under contract this weekend",
+        "Frisco ISD — some of the highest-rated schools in Texas",
+        "Updated kitchen & hardwoods — move-in ready, no immediate capex",
+      ],
+      aiConcerns: [],
+    },
+  },
+  {
+    id: "mock-003",
+    emailDelivered: true,
+    sentAt: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(), // 5 hrs ago
+    listing: {
+      id: "zpid-99124003",
+      address: "4012 Westgate Dr, Frisco, TX 75033",
+      price: 627000,
+      beds: 4,
+      baths: 3.5,
+      sqft: 2950,
+      yearBuilt: 2021,
+      lotSizeSqft: 6500,
+      hoaMonthly: 0,
+      daysOnMarket: 12,
+      listingType: "FOR_SALE",
+      pricePerSqft: 213,
+      zillowUrl: "https://www.zillow.com/homes/frisco-tx_rb/",
+      photos: [
+        "https://images.unsplash.com/photo-1600596542815-ffad4c1539a9?w=800&q=80",
+      ],
+      description:
+        "Near-new 2021 build — no HOA in Frisco is extraordinarily rare. Modern open floor plan with 10-ft ceilings, chef's kitchen with double ovens, butler's pantry, and dedicated home office. Tankless water heater, spray foam insulation.",
+      latitude: 33.1437,
+      longitude: -96.8603,
+      aiScore: 7,
+      alertTier: "MATCH",
+      aiReason:
+        "2021 build with no HOA is the headline here — that's genuinely uncommon in Frisco and saves $1,000–$2,400/yr vs comparable subdivisions. $213/sqft for a 3-year-old home is solid.",
+      aiHighlights: [
+        "NO HOA — saves $1,000–$2,400/yr vs comparable Frisco homes",
+        "2021 build — still under builder warranty period",
+        "$213/sqft — great value for 2021 construction",
+      ],
+      aiConcerns: [
+        "12 days on market — worth understanding why it hasn't moved faster",
+      ],
+    },
+  },
+  {
+    id: "mock-004",
+    emailDelivered: true,
+    sentAt: new Date(Date.now() - 11 * 60 * 60 * 1000).toISOString(), // 11 hrs ago
+    listing: {
+      id: "zpid-99124004",
+      address: "2845 Newcastle Dr, Frisco, TX 75036",
+      price: 498000,
+      beds: 3,
+      baths: 3,
+      sqft: 2100,
+      yearBuilt: 2014,
+      lotSizeSqft: 5800,
+      hoaMonthly: 150,
+      daysOnMarket: 21,
+      listingType: "FOR_SALE",
+      pricePerSqft: 237,
+      zillowUrl: "https://www.zillow.com/homes/frisco-tx_rb/",
+      photos: [
+        "https://images.unsplash.com/photo-1580587771525-78b9dba3b914?w=800&q=80",
+      ],
+      description:
+        "Lawler Park beauty with community amenities including resort-style pool, fitness center, and miles of walking trails. Updated bathrooms (2022), new HVAC (2023), and fresh exterior paint. Backs to greenbelt.",
+      latitude: 33.1348,
+      longitude: -96.8715,
+      aiScore: 6,
+      alertTier: "MATCH",
+      aiReason:
+        "Recent major mechanicals (HVAC 2023, baths 2022) reduce short-term maintenance risk. Greenbelt backing adds privacy and long-term value. 21 DOM suggests room for negotiation.",
+      aiHighlights: [
+        "New HVAC 2023 + updated baths 2022 — low near-term repair risk",
+        "Backs to greenbelt — privacy and no rear neighbors",
+        "21 DOM — seller likely motivated, negotiate below ask",
+      ],
+      aiConcerns: [
+        "HOA at $150/mo is on the higher end for this price tier",
+        "2014 build — roof and major systems approaching 10-yr mark",
+      ],
+    },
+  },
+  {
+    id: "mock-005",
+    emailDelivered: true,
+    sentAt: new Date(Date.now() - 26 * 60 * 60 * 1000).toISOString(), // yesterday
+    listing: {
+      id: "zpid-99124005",
+      address: "7721 Colby Ridge Rd, Frisco, TX 75035",
+      price: 643000,
+      beds: 5,
+      baths: 4,
+      sqft: 3280,
+      yearBuilt: 2013,
+      lotSizeSqft: 8400,
+      hoaMonthly: 200,
+      daysOnMarket: 5,
+      listingType: "FOR_SALE",
+      pricePerSqft: 196,
+      zillowUrl: "https://www.zillow.com/homes/frisco-tx_rb/",
+      photos: [
+        "https://images.unsplash.com/photo-1558618666-fcd25c85cd64?w=800&q=80",
+      ],
+      description:
+        "Exceptional 5-bedroom in Newman Village with media room, game room, and dedicated study. Remodeled kitchen with Carrara marble, farmhouse sink, and commercial-grade range. Resort backyard with pool, spa, and covered outdoor kitchen.",
+      latitude: 33.1655,
+      longitude: -96.8128,
+      aiScore: 9,
+      alertTier: "HOT",
+      aiReason:
+        "Pool + outdoor kitchen at $196/sqft for a 5/4 in Newman Village is exceptional — pool homes in this area routinely list at $220–$240/sqft. The game room and media room are high-demand features for families.",
+      aiHighlights: [
+        "$196/sqft with pool & outdoor kitchen — rare value",
+        "5 beds + game room + media room — maximum usable space",
+        "8,400 sqft lot with pool — premium outdoor living",
+      ],
+      aiConcerns: [
+        "HOA $200/mo — highest in this batch, verify what's included",
+      ],
+    },
+  },
+];
+
+export const MOCK_SCAN: ScanRecord = {
+  id: "mock-scan-001",
+  runAt: new Date(Date.now() - 18 * 60 * 1000).toISOString(),
+  listingsFound: 47,
+  newListings: 12,
+  matchedListings: 5,
+  alertsSent: 5,
+  durationMs: 14320,
+};
+
+export const MOCK_SCAN_HISTORY: ScanRecord[] = [
+  {
+    id: "mock-scan-003",
+    runAt: new Date(Date.now() - 18 * 60 * 1000).toISOString(),
+    listingsFound: 47,
+    newListings: 12,
+    matchedListings: 5,
+    alertsSent: 5,
+    durationMs: 14320,
+  },
+  {
+    id: "mock-scan-002",
+    runAt: new Date(Date.now() - 4 * 60 * 60 * 1000).toISOString(),
+    listingsFound: 44,
+    newListings: 3,
+    matchedListings: 1,
+    alertsSent: 1,
+    durationMs: 11480,
+  },
+  {
+    id: "mock-scan-001",
+    runAt: new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString(),
+    listingsFound: 41,
+    newListings: 0,
+    matchedListings: 0,
+    alertsSent: 0,
+    durationMs: 9870,
+  },
+  {
+    id: "mock-scan-y4",
+    runAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+    listingsFound: 39,
+    newListings: 7,
+    matchedListings: 2,
+    alertsSent: 2,
+    durationMs: 13210,
+  },
+  {
+    id: "mock-scan-y3",
+    runAt: new Date(Date.now() - 28 * 60 * 60 * 1000).toISOString(),
+    listingsFound: 37,
+    newListings: 1,
+    matchedListings: 0,
+    alertsSent: 0,
+    durationMs: 8950,
+  },
+  {
+    id: "mock-scan-y2",
+    runAt: new Date(Date.now() - 32 * 60 * 60 * 1000).toISOString(),
+    listingsFound: 36,
+    newListings: 4,
+    matchedListings: 1,
+    alertsSent: 1,
+    durationMs: 10340,
+  },
+  {
+    id: "mock-scan-y1",
+    runAt: new Date(Date.now() - 36 * 60 * 60 * 1000).toISOString(),
+    listingsFound: 32,
+    newListings: 0,
+    matchedListings: 0,
+    alertsSent: 0,
+    durationMs: 8120,
+  },
+];
+
+export const MOCK_STATS = {
+  todayScans: 3,
+  seenCount: 127,
+  lastScan: MOCK_SCAN,
+  totalAlerts: 5,
+  recentMatches: 5,
+};

--- a/lib/scorer.ts
+++ b/lib/scorer.ts
@@ -1,7 +1,7 @@
-import Anthropic from "@anthropic-ai/sdk";
+import OpenAI from "openai";
 import { ZillowListing, AIScoredListing, UserPreferences } from "./types";
 
-const client = new Anthropic();
+const client = new OpenAI();
 
 interface ScoreResult {
   score: number;
@@ -35,27 +35,18 @@ async function scoreListingOnce(
   listing: ZillowListing,
   prefs: UserPreferences
 ): Promise<ScoreResult> {
-  const message = await client.messages.create({
-    model: "claude-sonnet-4-6",
+  const response = await client.chat.completions.create({
+    model: "gpt-4o-mini",
     max_tokens: 500,
-    system: SYSTEM_PROMPT,
+    response_format: { type: "json_object" },
     messages: [
-      {
-        role: "user",
-        content: buildListingPrompt(listing, prefs),
-      },
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: buildListingPrompt(listing, prefs) },
     ],
   });
 
-  const content = message.content[0];
-  if (content.type !== "text") throw new Error("Unexpected response type");
-
-  const text = content.text.trim();
-  // Extract JSON — handle markdown code fences if present
-  const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/) ?? null;
-  const jsonText = jsonMatch ? jsonMatch[1] : text;
-
-  return JSON.parse(jsonText) as ScoreResult;
+  const text = response.choices[0]?.message?.content?.trim() ?? "";
+  return JSON.parse(text) as ScoreResult;
 }
 
 export async function scoreListing(

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -3,6 +3,8 @@ import {
   UserPreferences,
   AlertRecord,
   ScanRecord,
+  BookmarkedListing,
+  AIScoredListing,
   DEFAULT_PREFERENCES,
 } from "./types";
 
@@ -44,7 +46,8 @@ export async function getSeenIds(): Promise<Set<string>> {
 export async function addSeenIds(ids: string[]): Promise<void> {
   if (ids.length === 0) return;
   try {
-    await kv.sadd(KEYS.SEEN_IDS, ...ids);
+    // @vercel/kv sadd accepts a single member or array via cast
+    await (kv.sadd as (key: string, ...members: string[]) => Promise<number>)(KEYS.SEEN_IDS, ...ids);
   } catch {
     // non-fatal
   }
@@ -120,5 +123,65 @@ export async function getLastScanRecord(): Promise<ScanRecord | null> {
     return item as ScanRecord;
   } catch {
     return null;
+  }
+}
+
+// ─── Bookmarks ────────────────────────────────────────────────────────────────
+
+const BOOKMARKS_KEY = "hyh:bookmarks";
+
+export async function getBookmarks(): Promise<BookmarkedListing[]> {
+  try {
+    const data = await kv.hgetall(BOOKMARKS_KEY);
+    if (!data) return [];
+    return Object.values(data).map((v) => {
+      if (typeof v === "string") return JSON.parse(v) as BookmarkedListing;
+      return v as BookmarkedListing;
+    });
+  } catch {
+    return [];
+  }
+}
+
+export async function addBookmark(listing: AIScoredListing): Promise<void> {
+  try {
+    const bookmark: BookmarkedListing = {
+      listing,
+      savedAt: new Date().toISOString(),
+      sold: false,
+    };
+    await kv.hset(BOOKMARKS_KEY, { [listing.id]: JSON.stringify(bookmark) });
+  } catch {
+    // non-fatal
+  }
+}
+
+export async function removeBookmark(zpid: string): Promise<void> {
+  try {
+    await kv.hdel(BOOKMARKS_KEY, zpid);
+  } catch {
+    // non-fatal
+  }
+}
+
+export async function markBookmarkSold(zpid: string): Promise<void> {
+  try {
+    const raw = await kv.hget<string>(BOOKMARKS_KEY, zpid);
+    if (!raw) return;
+    const bookmark: BookmarkedListing =
+      typeof raw === "string" ? JSON.parse(raw) : (raw as BookmarkedListing);
+    bookmark.sold = true;
+    await kv.hset(BOOKMARKS_KEY, { [zpid]: JSON.stringify(bookmark) });
+  } catch {
+    // non-fatal
+  }
+}
+
+export async function getBookmarkIds(): Promise<Set<string>> {
+  try {
+    const keys = await kv.hkeys(BOOKMARKS_KEY);
+    return new Set(keys as string[]);
+  } catch {
+    return new Set();
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -58,6 +58,12 @@ export interface ScanRecord {
   durationMs: number;
 }
 
+export interface BookmarkedListing {
+  listing: AIScoredListing;
+  savedAt: string;
+  sold: boolean;
+}
+
 export const DEFAULT_PREFERENCES: UserPreferences = {
   minBeds: 3,
   minBaths: 2,

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,26 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "photos.zillowstatic.com",
+      },
+      {
+        protocol: "https",
+        hostname: "**.zillowstatic.com",
+      },
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+      },
+      {
+        protocol: "https",
+        hostname: "**.amazonaws.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.82.0",
     "@base-ui/react": "^1.3.0",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-switch": "^1.2.6",
@@ -22,6 +24,7 @@
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.7.0",
     "next": "16.2.2",
+    "openai": "^6.33.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-email": "^5.2.10",
@@ -39,7 +42,10 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/uuid": "^11.0.0",
+    "@vitest/coverage-v8": "^4.1.2",
+    "jsdom": "^29.0.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.82.0
-        version: 0.82.0(zod@3.25.76)
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -50,6 +47,9 @@ importers:
       next:
         specifier: 16.2.2
         version: 16.2.2(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      openai:
+        specifier: ^6.33.0
+        version: 6.33.0(ws@8.18.3)(zod@3.25.76)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -96,12 +96,21 @@ importers:
       '@types/uuid':
         specifier: ^11.0.0
         version: 11.0.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.2
+        version: 4.1.2(vitest@4.1.2(@types/node@20.19.37)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.3)(jiti@2.6.1)))
+      jsdom:
+        specifier: ^29.0.1
+        version: 29.0.1(@noble/hashes@1.8.0)
       tailwindcss:
         specifier: ^4
         version: 4.2.2
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@types/node@20.19.37)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.3)(jiti@2.6.1))
 
 packages:
 
@@ -109,14 +118,16 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@anthropic-ai/sdk@0.82.0':
-    resolution: {integrity: sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
+  '@asamuzakjp/css-color@5.1.4':
+    resolution: {integrity: sha512-503MoTEmPSyEJ7zQ+5vlkwPtkyxDhbDwR9ajk/jpPGrCLiUFHzgEG4iViUPKdGlZPRT1mWSPSbDL2qkOoLU4vg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    resolution: {integrity: sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -281,6 +292,50 @@ packages:
       '@types/react':
         optional: true
 
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@dotenvx/dotenvx@1.59.1':
     resolution: {integrity: sha512-Qg+meC+XFxliuVSDlEPkKnaUjdaJKK6FNx/Wwl2UxhQR8pyPIuLhMavsF7ePdB9qFZUWV1jEK3ckbJir/WmF4w==}
     hasBin: true
@@ -291,8 +346,14 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -449,6 +510,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -689,6 +759,12 @@ packages:
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
 
+  '@napi-rs/wasm-runtime@1.1.2':
+    resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.2':
     resolution: {integrity: sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==}
 
@@ -776,6 +852,9 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@oxc-project/types@0.122.0':
+    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1204,6 +1283,104 @@ packages:
       react-redux:
         optional: true
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.12':
+    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -1324,6 +1501,12 @@ packages:
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
@@ -1353,6 +1536,12 @@ packages:
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
@@ -1388,6 +1577,44 @@ packages:
     resolution: {integrity: sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==}
     engines: {node: '>=14.6'}
     deprecated: 'Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis'
+
+  '@vitest/coverage-v8@4.1.2':
+    resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
+    peerDependencies:
+      '@vitest/browser': 4.1.2
+      vitest: 4.1.2
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -1427,9 +1654,16 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   atomically@2.1.1:
     resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
@@ -1446,6 +1680,9 @@ packages:
     resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -1486,6 +1723,10 @@ packages:
 
   caniuse-lite@1.0.30001784:
     resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -1597,6 +1838,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1653,6 +1898,10 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
@@ -1675,6 +1924,9 @@ packages:
 
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
@@ -1773,6 +2025,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -1791,6 +2047,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1816,6 +2075,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -1838,6 +2100,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.3.2:
     resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
@@ -1923,6 +2189,11 @@ packages:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -1984,6 +2255,10 @@ packages:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -1998,6 +2273,13 @@ packages:
   hono@4.12.10:
     resolution: {integrity: sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==}
     engines: {node: '>=16.9.0'}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -2103,6 +2385,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -2137,6 +2422,18 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
@@ -2148,12 +2445,24 @@ packages:
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.0.1:
+    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2162,10 +2471,6 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-
-  json-schema-to-ts@3.1.1:
-    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
-    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -2292,6 +2597,13 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
     engines: {node: '>= 18'}
@@ -2300,6 +2612,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -2453,6 +2768,9 @@ packages:
     resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
     engines: {node: '>= 10'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -2472,6 +2790,18 @@ packages:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
 
+  openai@6.33.0:
+    resolution: {integrity: sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
@@ -2490,6 +2820,9 @@ packages:
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -2582,6 +2915,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
@@ -2686,6 +3023,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-rc.12:
+    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -2699,6 +3041,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2758,6 +3104,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2793,12 +3142,18 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -2858,8 +3213,15 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   svix@1.88.0:
     resolution: {integrity: sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
@@ -2881,9 +3243,20 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.27:
     resolution: {integrity: sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==}
@@ -2904,8 +3277,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
-  ts-algebra@2.0.0:
-    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -2942,6 +3316,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.24.7:
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -2991,9 +3369,103 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
+  vite@8.0.3:
+    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
@@ -3006,6 +3478,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@6.2.0:
@@ -3034,6 +3511,13 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -3070,11 +3554,23 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/sdk@0.82.0(zod@3.25.76)':
+  '@asamuzakjp/css-color@5.1.4':
     dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 3.25.76
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/dom-selector@7.0.4':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3304,6 +3800,36 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@dotenvx/dotenvx@1.59.1':
     dependencies:
       commander: 11.1.0
@@ -3320,7 +3846,18 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -3402,6 +3939,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
+
+  '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
+    optionalDependencies:
+      '@noble/hashes': 1.8.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -3599,6 +4140,13 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
+  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@16.2.2': {}
 
   '@next/swc-darwin-arm64@16.2.2':
@@ -3653,6 +4201,8 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@oxc-project/types@0.122.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -4023,6 +4573,58 @@ snapshots:
       react: 19.2.4
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.12': {}
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@selderee/plugin-htmlparser2@0.11.0':
@@ -4119,6 +4721,16 @@ snapshots:
       minimatch: 10.2.5
       path-browserify: 1.0.1
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 20.19.37
@@ -4146,6 +4758,10 @@ snapshots:
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/node@20.19.37':
     dependencies:
@@ -4181,6 +4797,62 @@ snapshots:
     dependencies:
       '@upstash/redis': 1.37.0
 
+  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@20.19.37)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.3)(jiti@2.6.1)))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.2
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.2(@types/node@20.19.37)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.3)(jiti@2.6.1))
+
+  '@vitest/expect@4.1.2':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.2(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.3)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.14(@types/node@20.19.37)(typescript@5.9.3)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.3)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.2':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.2':
+    dependencies:
+      '@vitest/utils': 4.1.2
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.2': {}
+
+  '@vitest/utils@4.1.2':
+    dependencies:
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -4214,9 +4886,17 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   atomically@2.1.1:
     dependencies:
@@ -4228,6 +4908,10 @@ snapshots:
   base64id@2.0.0: {}
 
   baseline-browser-mapping@2.10.13: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   body-parser@2.2.2:
     dependencies:
@@ -4278,6 +4962,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001784: {}
+
+  chai@6.2.2: {}
 
   chalk@5.6.2: {}
 
@@ -4373,6 +5059,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -4417,6 +5108,13 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-urls@7.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   date-fns@4.1.0: {}
 
   debounce-fn@6.0.0:
@@ -4430,6 +5128,8 @@ snapshots:
       ms: 2.1.3
 
   decimal.js-light@2.5.1: {}
+
+  decimal.js@10.6.0: {}
 
   dedent@1.7.2: {}
 
@@ -4523,6 +5223,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   env-paths@2.2.1: {}
 
   env-paths@3.0.0: {}
@@ -4534,6 +5236,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -4576,6 +5280,10 @@ snapshots:
 
   esprima@4.0.1: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   etag@1.8.1: {}
 
   eventemitter3@5.0.4: {}
@@ -4612,6 +5320,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
@@ -4722,6 +5432,9 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fsevents@2.3.3:
+    optional: true
+
   function-bind@1.1.2: {}
 
   fuzzysort@3.1.0: {}
@@ -4777,6 +5490,8 @@ snapshots:
 
   graphql@16.13.2: {}
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.2:
@@ -4786,6 +5501,14 @@ snapshots:
   headers-polyfill@4.0.3: {}
 
   hono@4.12.10: {}
+
+  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   html-to-text@9.0.5:
     dependencies:
@@ -4872,6 +5595,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regexp@3.1.0: {}
@@ -4892,11 +5617,26 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.4.2: {}
 
   jiti@2.6.1: {}
 
   jose@6.2.2: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -4904,14 +5644,35 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@29.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.4
+      '@asamuzakjp/dom-selector': 7.0.4
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@1.8.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.7
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.24.7
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@1.8.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   jsesc@3.1.0: {}
 
   json-parse-even-better-errors@2.3.1: {}
-
-  json-schema-to-ts@3.1.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
-      ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
 
@@ -5006,9 +5767,21 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
   marked@15.0.12: {}
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -5147,6 +5920,8 @@ snapshots:
 
   object-treeify@1.1.33: {}
 
+  obug@2.1.1: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -5171,6 +5946,11 @@ snapshots:
       is-inside-container: 1.0.0
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
+
+  openai@6.33.0(ws@8.18.3)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.18.3
+      zod: 3.25.76
 
   ora@8.2.0:
     dependencies:
@@ -5198,6 +5978,10 @@ snapshots:
       lines-and-columns: 1.2.4
 
   parse-ms@4.0.0: {}
+
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
 
   parseley@0.12.1:
     dependencies:
@@ -5277,6 +6061,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  punycode@2.3.1: {}
 
   qs@6.15.0:
     dependencies:
@@ -5395,6 +6181,30 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+    dependencies:
+      '@oxc-project/types': 0.122.0
+      '@rolldown/pluginutils': 1.0.0-rc.12
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -5412,6 +6222,10 @@ snapshots:
       queue-microtask: 1.2.3
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -5559,6 +6373,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -5604,12 +6420,16 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  stackback@0.0.2: {}
+
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
+
+  std-env@4.0.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -5660,10 +6480,16 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   svix@1.88.0:
     dependencies:
       standardwebhooks: 1.0.0
       uuid: 10.0.0
+
+  symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
 
@@ -5677,7 +6503,16 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.4: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.27: {}
 
@@ -5695,7 +6530,9 @@ snapshots:
     dependencies:
       tldts: 7.0.27
 
-  ts-algebra@2.0.0: {}
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-morph@26.0.0:
     dependencies:
@@ -5729,6 +6566,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.24.7: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -5775,7 +6614,67 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.3)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 20.19.37
+      esbuild: 0.27.3
+      fsevents: 2.3.3
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  vitest@4.1.2(@types/node@20.19.37)(jsdom@29.0.1(@noble/hashes@1.8.0))(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.3)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@20.19.37)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.3)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.37)(esbuild@0.27.3)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.37
+      jsdom: 29.0.1(@noble/hashes@1.8.0)
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@1.8.0):
+    dependencies:
+      '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   when-exit@2.1.5: {}
 
@@ -5786,6 +6685,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -5807,6 +6711,10 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/tests/bookmarks.test.ts
+++ b/tests/bookmarks.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+import { MOCK_ALERTS } from "@/lib/mock-data";
+import { BookmarkedListing, AIScoredListing } from "@/lib/types";
+
+// Pure bookmark state helpers (mirrors logic in page components)
+function addToBookmarks(
+  bookmarks: BookmarkedListing[],
+  listing: AIScoredListing
+): BookmarkedListing[] {
+  if (bookmarks.some((b) => b.listing.id === listing.id)) return bookmarks;
+  return [...bookmarks, { listing, savedAt: new Date().toISOString(), sold: false }];
+}
+
+function removeFromBookmarks(
+  bookmarks: BookmarkedListing[],
+  zpid: string
+): BookmarkedListing[] {
+  return bookmarks.filter((b) => b.listing.id !== zpid);
+}
+
+function markSold(bookmarks: BookmarkedListing[], zpid: string): BookmarkedListing[] {
+  return bookmarks.map((b) =>
+    b.listing.id === zpid ? { ...b, sold: true } : b
+  );
+}
+
+function filterSoldFromFeed(
+  alerts: typeof MOCK_ALERTS,
+  bookmarks: BookmarkedListing[]
+): typeof MOCK_ALERTS {
+  const soldZpids = new Set(
+    bookmarks.filter((b) => b.sold).map((b) => b.listing.id)
+  );
+  return alerts.filter((a) => !soldZpids.has(a.listing.id));
+}
+
+const listing1 = MOCK_ALERTS[0].listing;
+const listing2 = MOCK_ALERTS[1].listing;
+const listing3 = MOCK_ALERTS[2].listing;
+
+describe("Bookmark add / remove", () => {
+  it("adds a listing to bookmarks", () => {
+    const result = addToBookmarks([], listing1);
+    expect(result).toHaveLength(1);
+    expect(result[0].listing.id).toBe(listing1.id);
+    expect(result[0].sold).toBe(false);
+  });
+
+  it("does not duplicate an already-bookmarked listing", () => {
+    const once = addToBookmarks([], listing1);
+    const twice = addToBookmarks(once, listing1);
+    expect(twice).toHaveLength(1);
+  });
+
+  it("adds multiple different listings", () => {
+    let bm: BookmarkedListing[] = [];
+    bm = addToBookmarks(bm, listing1);
+    bm = addToBookmarks(bm, listing2);
+    expect(bm).toHaveLength(2);
+  });
+
+  it("removes a listing by zpid", () => {
+    const bm = addToBookmarks([], listing1);
+    const result = removeFromBookmarks(bm, listing1.id);
+    expect(result).toHaveLength(0);
+  });
+
+  it("removing a non-existent zpid is a no-op", () => {
+    const bm = addToBookmarks([], listing1);
+    const result = removeFromBookmarks(bm, "zpid-does-not-exist");
+    expect(result).toHaveLength(1);
+  });
+
+  it("savedAt is a valid ISO date string", () => {
+    const result = addToBookmarks([], listing1);
+    expect(() => new Date(result[0].savedAt)).not.toThrow();
+    expect(new Date(result[0].savedAt).getTime()).not.toBeNaN();
+  });
+});
+
+describe("Bookmark sold state", () => {
+  it("marks a listing as sold", () => {
+    let bm = addToBookmarks([], listing1);
+    bm = markSold(bm, listing1.id);
+    expect(bm[0].sold).toBe(true);
+  });
+
+  it("marking sold does not affect other bookmarks", () => {
+    let bm: BookmarkedListing[] = [];
+    bm = addToBookmarks(bm, listing1);
+    bm = addToBookmarks(bm, listing2);
+    bm = markSold(bm, listing1.id);
+    expect(bm.find((b) => b.listing.id === listing2.id)!.sold).toBe(false);
+  });
+
+  it("marking an unknown zpid as sold is a no-op", () => {
+    let bm = addToBookmarks([], listing1);
+    bm = markSold(bm, "zpid-unknown");
+    expect(bm[0].sold).toBe(false);
+  });
+});
+
+describe("Dashboard feed filtering of sold bookmarks", () => {
+  it("does not filter listings when no bookmarks are sold", () => {
+    const bm = addToBookmarks([], listing1);
+    const result = filterSoldFromFeed(MOCK_ALERTS, bm);
+    expect(result).toHaveLength(MOCK_ALERTS.length);
+  });
+
+  it("removes a sold listing from the feed", () => {
+    let bm = addToBookmarks([], listing1);
+    bm = markSold(bm, listing1.id);
+    const result = filterSoldFromFeed(MOCK_ALERTS, bm);
+    expect(result).toHaveLength(MOCK_ALERTS.length - 1);
+    expect(result.find((a) => a.listing.id === listing1.id)).toBeUndefined();
+  });
+
+  it("removes multiple sold listings from the feed", () => {
+    let bm: BookmarkedListing[] = [];
+    bm = addToBookmarks(bm, listing1);
+    bm = addToBookmarks(bm, listing2);
+    bm = markSold(bm, listing1.id);
+    bm = markSold(bm, listing2.id);
+    const result = filterSoldFromFeed(MOCK_ALERTS, bm);
+    expect(result).toHaveLength(MOCK_ALERTS.length - 2);
+  });
+
+  it("keeps non-sold bookmarked listings in the feed", () => {
+    let bm: BookmarkedListing[] = [];
+    bm = addToBookmarks(bm, listing1);
+    bm = addToBookmarks(bm, listing2);
+    bm = markSold(bm, listing1.id); // only sold listing1
+    const result = filterSoldFromFeed(MOCK_ALERTS, bm);
+    expect(result.find((a) => a.listing.id === listing2.id)).toBeDefined();
+  });
+
+  it("returns full feed when bookmarks list is empty", () => {
+    const result = filterSoldFromFeed(MOCK_ALERTS, []);
+    expect(result).toHaveLength(MOCK_ALERTS.length);
+  });
+
+  it("bookmarks page splits active vs sold correctly", () => {
+    let bm: BookmarkedListing[] = [];
+    bm = addToBookmarks(bm, listing1);
+    bm = addToBookmarks(bm, listing2);
+    bm = addToBookmarks(bm, listing3);
+    bm = markSold(bm, listing1.id);
+
+    const active = bm.filter((b) => !b.sold);
+    const sold = bm.filter((b) => b.sold);
+
+    expect(active).toHaveLength(2);
+    expect(sold).toHaveLength(1);
+    expect(sold[0].listing.id).toBe(listing1.id);
+  });
+});
+
+describe("Sold detection logic (scrape route simulation)", () => {
+  it("detects a bookmarked listing missing from active FOR_SALE results", () => {
+    const bookmarkIds = new Set([listing1.id, listing2.id]);
+    // Active scrape results only contain listing2
+    const activeForSaleIds = new Set([listing2.id, listing3.id]);
+
+    const soldZpids: string[] = [];
+    for (const zpid of bookmarkIds) {
+      if (!activeForSaleIds.has(zpid)) {
+        soldZpids.push(zpid);
+      }
+    }
+
+    expect(soldZpids).toEqual([listing1.id]);
+  });
+
+  it("does not mark listings as sold when all bookmarks appear in active results", () => {
+    const bookmarkIds = new Set([listing1.id, listing2.id]);
+    const activeForSaleIds = new Set([listing1.id, listing2.id, listing3.id]);
+
+    const soldZpids: string[] = [];
+    for (const zpid of bookmarkIds) {
+      if (!activeForSaleIds.has(zpid)) {
+        soldZpids.push(zpid);
+      }
+    }
+
+    expect(soldZpids).toHaveLength(0);
+  });
+
+  it("marks all bookmarks as sold when scrape returns empty results", () => {
+    const bookmarkIds = new Set([listing1.id, listing2.id]);
+    const activeForSaleIds = new Set<string>();
+
+    const soldZpids: string[] = [];
+    for (const zpid of bookmarkIds) {
+      if (!activeForSaleIds.has(zpid)) {
+        soldZpids.push(zpid);
+      }
+    }
+
+    expect(soldZpids).toHaveLength(2);
+  });
+});

--- a/tests/cookie-prefs.test.ts
+++ b/tests/cookie-prefs.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  savePrefsToookie,
+  getPrefsFromCookie,
+  clearPrefsCookie,
+  mergeWithDefaults,
+} from "@/lib/cookie-prefs";
+import { DEFAULT_PREFERENCES } from "@/lib/types";
+
+// jsdom provides document.cookie — reset between tests
+beforeEach(() => {
+  // Clear all cookies by expiring them
+  const cookies = document.cookie.split(";");
+  for (const cookie of cookies) {
+    const name = cookie.split("=")[0].trim();
+    if (name) {
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/`;
+    }
+  }
+});
+
+describe("savePrefsToookie / getPrefsFromCookie", () => {
+  it("round-trips preferences through cookie", () => {
+    const prefs = { ...DEFAULT_PREFERENCES, alertEmail: "test@example.com" };
+    savePrefsToookie(prefs);
+    const result = getPrefsFromCookie();
+    expect(result).not.toBeNull();
+    expect(result!.alertEmail).toBe("test@example.com");
+  });
+
+  it("returns null when no cookie is set", () => {
+    expect(getPrefsFromCookie()).toBeNull();
+  });
+
+  it("persists all preference fields accurately", () => {
+    const prefs = {
+      ...DEFAULT_PREFERENCES,
+      minBeds: 4,
+      maxPrice: 600000,
+      scoreThreshold: 7,
+    };
+    savePrefsToookie(prefs);
+    const result = getPrefsFromCookie();
+    expect(result!.minBeds).toBe(4);
+    expect(result!.maxPrice).toBe(600000);
+    expect(result!.scoreThreshold).toBe(7);
+  });
+});
+
+describe("clearPrefsCookie", () => {
+  it("removes the cookie so getPrefsFromCookie returns null", () => {
+    savePrefsToookie(DEFAULT_PREFERENCES);
+    expect(getPrefsFromCookie()).not.toBeNull();
+    clearPrefsCookie();
+    expect(getPrefsFromCookie()).toBeNull();
+  });
+});
+
+describe("mergeWithDefaults", () => {
+  it("fills missing keys from DEFAULT_PREFERENCES", () => {
+    const partial = { alertEmail: "hello@test.com" };
+    const merged = mergeWithDefaults(partial);
+    expect(merged.minBeds).toBe(DEFAULT_PREFERENCES.minBeds);
+    expect(merged.maxPrice).toBe(DEFAULT_PREFERENCES.maxPrice);
+    expect(merged.alertEmail).toBe("hello@test.com");
+  });
+
+  it("partial value overrides default", () => {
+    const merged = mergeWithDefaults({ minBeds: 5 });
+    expect(merged.minBeds).toBe(5);
+  });
+
+  it("returns a complete UserPreferences object", () => {
+    const merged = mergeWithDefaults({});
+    const requiredKeys: (keyof typeof DEFAULT_PREFERENCES)[] = [
+      "minBeds",
+      "minBaths",
+      "maxPrice",
+      "minPrice",
+      "minSqft",
+      "maxHoa",
+      "requireGarage",
+      "minYearBuilt",
+      "searchArea",
+      "alertEmail",
+      "scoreThreshold",
+      "hotScoreThreshold",
+    ];
+    requiredKeys.forEach((key) => {
+      expect(merged).toHaveProperty(key);
+    });
+  });
+});

--- a/tests/filters.test.ts
+++ b/tests/filters.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { matchesHardFilters } from "@/lib/filters";
+import { ZillowListing, UserPreferences, DEFAULT_PREFERENCES } from "@/lib/types";
+
+// Base listing that satisfies DEFAULT_PREFERENCES
+const BASE_LISTING: ZillowListing = {
+  id: "zpid-test-001",
+  address: "123 Main St, Frisco, TX 75035",
+  price: 500000,
+  beds: 4,
+  baths: 3,
+  sqft: 2400,
+  yearBuilt: 2010,
+  daysOnMarket: 5,
+  photos: [],
+  zillowUrl: "https://www.zillow.com/test",
+  listingType: "FOR_SALE",
+};
+
+const PREFS: UserPreferences = { ...DEFAULT_PREFERENCES };
+
+describe("matchesHardFilters", () => {
+  it("passes a listing that meets all default criteria", () => {
+    expect(matchesHardFilters(BASE_LISTING, PREFS)).toBe(true);
+  });
+
+  // listingType
+  it("rejects a PENDING listing", () => {
+    expect(matchesHardFilters({ ...BASE_LISTING, listingType: "PENDING" }, PREFS)).toBe(false);
+  });
+
+  // Price
+  it("rejects listing above maxPrice", () => {
+    expect(matchesHardFilters({ ...BASE_LISTING, price: 700000 }, PREFS)).toBe(false);
+  });
+
+  it("rejects listing below minPrice", () => {
+    const prefs: UserPreferences = { ...PREFS, minPrice: 400000 };
+    expect(matchesHardFilters({ ...BASE_LISTING, price: 300000 }, prefs)).toBe(false);
+  });
+
+  it("accepts listing exactly at maxPrice boundary", () => {
+    expect(matchesHardFilters({ ...BASE_LISTING, price: 650000 }, PREFS)).toBe(true);
+  });
+
+  it("accepts listing exactly at minPrice boundary", () => {
+    const prefs: UserPreferences = { ...PREFS, minPrice: 400000 };
+    expect(matchesHardFilters({ ...BASE_LISTING, price: 400000 }, prefs)).toBe(true);
+  });
+
+  // Beds
+  it("rejects listing with fewer beds than minBeds", () => {
+    expect(matchesHardFilters({ ...BASE_LISTING, beds: 2 }, PREFS)).toBe(false);
+  });
+
+  it("accepts listing with exactly minBeds", () => {
+    expect(matchesHardFilters({ ...BASE_LISTING, beds: PREFS.minBeds }, PREFS)).toBe(true);
+  });
+
+  // Baths
+  it("rejects listing with fewer baths than minBaths", () => {
+    expect(matchesHardFilters({ ...BASE_LISTING, baths: 1 }, PREFS)).toBe(false);
+  });
+
+  // Sqft
+  it("rejects listing below minSqft", () => {
+    expect(matchesHardFilters({ ...BASE_LISTING, sqft: 1000 }, PREFS)).toBe(false);
+  });
+
+  it("accepts listing exactly at minSqft", () => {
+    expect(matchesHardFilters({ ...BASE_LISTING, sqft: PREFS.minSqft }, PREFS)).toBe(true);
+  });
+
+  // Year built
+  it("rejects listing built before minYearBuilt", () => {
+    expect(matchesHardFilters({ ...BASE_LISTING, yearBuilt: 1980 }, PREFS)).toBe(false);
+  });
+
+  it("accepts listing built exactly at minYearBuilt", () => {
+    expect(matchesHardFilters({ ...BASE_LISTING, yearBuilt: PREFS.minYearBuilt }, PREFS)).toBe(true);
+  });
+
+  // HOA
+  it("rejects listing with HOA over maxHoa when maxHoa is set", () => {
+    const prefs: UserPreferences = { ...PREFS, maxHoa: 100 };
+    expect(matchesHardFilters({ ...BASE_LISTING, hoaMonthly: 200 }, prefs)).toBe(false);
+  });
+
+  it("accepts listing with HOA under maxHoa", () => {
+    const prefs: UserPreferences = { ...PREFS, maxHoa: 200 };
+    expect(matchesHardFilters({ ...BASE_LISTING, hoaMonthly: 150 }, prefs)).toBe(true);
+  });
+
+  it("accepts listing with HOA when maxHoa is null (no restriction)", () => {
+    const prefs: UserPreferences = { ...PREFS, maxHoa: null };
+    expect(matchesHardFilters({ ...BASE_LISTING, hoaMonthly: 999 }, prefs)).toBe(true);
+  });
+
+  it("accepts listing with no HOA field regardless of maxHoa", () => {
+    const prefs: UserPreferences = { ...PREFS, maxHoa: 0 };
+    const listingNoHoa = { ...BASE_LISTING };
+    delete (listingNoHoa as Partial<ZillowListing>).hoaMonthly;
+    expect(matchesHardFilters(listingNoHoa, prefs)).toBe(true);
+  });
+});

--- a/tests/mock-data.test.ts
+++ b/tests/mock-data.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { MOCK_ALERTS, MOCK_STATS, MOCK_SCAN, MOCK_SCAN_HISTORY } from "@/lib/mock-data";
+
+describe("MOCK_ALERTS", () => {
+  it("contains 5 listings", () => {
+    expect(MOCK_ALERTS).toHaveLength(5);
+  });
+
+  it("every listing has a unique id", () => {
+    const ids = MOCK_ALERTS.map((r) => r.listing.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every listing is FOR_SALE", () => {
+    MOCK_ALERTS.forEach((r) => {
+      expect(r.listing.listingType).toBe("FOR_SALE");
+    });
+  });
+
+  it("all prices are under $650k (our max)", () => {
+    MOCK_ALERTS.forEach((r) => {
+      expect(r.listing.price).toBeLessThanOrEqual(650000);
+    });
+  });
+
+  it("all listings have 3+ beds", () => {
+    MOCK_ALERTS.forEach((r) => {
+      expect(r.listing.beds).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it("all listings have 3+ baths", () => {
+    MOCK_ALERTS.forEach((r) => {
+      expect(r.listing.baths).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it("every alert has a valid alertTier", () => {
+    MOCK_ALERTS.forEach((r) => {
+      expect(["HOT", "MATCH"]).toContain(r.listing.alertTier);
+    });
+  });
+
+  it("every alert has an aiScore between 1 and 10", () => {
+    MOCK_ALERTS.forEach((r) => {
+      expect(r.listing.aiScore).toBeGreaterThanOrEqual(1);
+      expect(r.listing.aiScore).toBeLessThanOrEqual(10);
+    });
+  });
+
+  it("HOT tier listings have aiScore >= 8", () => {
+    MOCK_ALERTS.filter((r) => r.listing.alertTier === "HOT").forEach((r) => {
+      expect(r.listing.aiScore).toBeGreaterThanOrEqual(8);
+    });
+  });
+
+  it("every listing has at least one photo", () => {
+    MOCK_ALERTS.forEach((r) => {
+      expect(r.listing.photos.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("every listing has aiHighlights array", () => {
+    MOCK_ALERTS.forEach((r) => {
+      expect(Array.isArray(r.listing.aiHighlights)).toBe(true);
+    });
+  });
+
+  it("every alert record has sentAt as valid ISO string", () => {
+    MOCK_ALERTS.forEach((r) => {
+      expect(() => new Date(r.sentAt)).not.toThrow();
+      expect(new Date(r.sentAt).getTime()).not.toBeNaN();
+    });
+  });
+});
+
+describe("MOCK_SCAN_HISTORY", () => {
+  it("contains 7 scan records", () => {
+    expect(MOCK_SCAN_HISTORY).toHaveLength(7);
+  });
+
+  it("every scan has a unique id", () => {
+    const ids = MOCK_SCAN_HISTORY.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every scan has a positive durationMs", () => {
+    MOCK_SCAN_HISTORY.forEach((s) => {
+      expect(s.durationMs).toBeGreaterThan(0);
+    });
+  });
+
+  it("alertsSent is always <= matchedListings", () => {
+    MOCK_SCAN_HISTORY.forEach((s) => {
+      expect(s.alertsSent).toBeLessThanOrEqual(s.matchedListings);
+    });
+  });
+
+  it("matchedListings is always <= newListings", () => {
+    MOCK_SCAN_HISTORY.forEach((s) => {
+      expect(s.matchedListings).toBeLessThanOrEqual(s.newListings);
+    });
+  });
+
+  it("newListings is always <= listingsFound", () => {
+    MOCK_SCAN_HISTORY.forEach((s) => {
+      expect(s.newListings).toBeLessThanOrEqual(s.listingsFound);
+    });
+  });
+});
+
+describe("MOCK_STATS", () => {
+  it("has all required stat fields", () => {
+    expect(MOCK_STATS).toHaveProperty("todayScans");
+    expect(MOCK_STATS).toHaveProperty("seenCount");
+    expect(MOCK_STATS).toHaveProperty("lastScan");
+    expect(MOCK_STATS).toHaveProperty("totalAlerts");
+    expect(MOCK_STATS).toHaveProperty("recentMatches");
+  });
+
+  it("todayScans is a non-negative number", () => {
+    expect(MOCK_STATS.todayScans).toBeGreaterThanOrEqual(0);
+  });
+
+  it("lastScan matches MOCK_SCAN shape", () => {
+    expect(MOCK_STATS.lastScan).toEqual(MOCK_SCAN);
+  });
+});

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_PREFERENCES } from "@/lib/types";
+
+describe("DEFAULT_PREFERENCES", () => {
+  it("has the correct Frisco, TX search area", () => {
+    expect(DEFAULT_PREFERENCES.searchArea).toBe("Frisco, TX");
+  });
+
+  it("has minBeds of 3", () => {
+    expect(DEFAULT_PREFERENCES.minBeds).toBe(3);
+  });
+
+  it("has minBaths of 2", () => {
+    expect(DEFAULT_PREFERENCES.minBaths).toBe(2);
+  });
+
+  it("has maxPrice of 650000", () => {
+    expect(DEFAULT_PREFERENCES.maxPrice).toBe(650000);
+  });
+
+  it("has minSqft of 1800", () => {
+    expect(DEFAULT_PREFERENCES.minSqft).toBe(1800);
+  });
+
+  it("has scoreThreshold of 6", () => {
+    expect(DEFAULT_PREFERENCES.scoreThreshold).toBe(6);
+  });
+
+  it("has hotScoreThreshold of 8", () => {
+    expect(DEFAULT_PREFERENCES.hotScoreThreshold).toBe(8);
+  });
+
+  it("hotScoreThreshold is greater than scoreThreshold", () => {
+    expect(DEFAULT_PREFERENCES.hotScoreThreshold).toBeGreaterThan(
+      DEFAULT_PREFERENCES.scoreThreshold
+    );
+  });
+
+  it("maxHoa is null by default (no restriction)", () => {
+    expect(DEFAULT_PREFERENCES.maxHoa).toBeNull();
+  });
+
+  it("has empty alertEmail by default", () => {
+    expect(DEFAULT_PREFERENCES.alertEmail).toBe("");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary"],
+      include: ["lib/**/*.ts"],
+      exclude: ["lib/apify.ts", "lib/scorer.ts", "lib/email.ts"],
+    },
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- **Bookmarks** — star icon on every listing card saves/unsaves homes. Stored in Vercel KV (prod) or localStorage (mock). \`/bookmarks\` page shows active listings and a \`HOME SOLD\` section for any bookmarked home that disappeared from Zillow's active FOR_SALE results. Sold listings are also filtered out of the dashboard and alerts feed.
- **Mock mode gate** — \`NEXT_PUBLIC_ENABLE_MOCK=true\` in \`.env.local\` enables the mock toggle in dev. In production (env var absent) the toggle button, mock banner, and all mock data paths are dead-branched at build time — nothing leaks.
- **OpenAI scorer** — swapped \`@anthropic-ai/sdk\` for \`openai\` (gpt-4o-mini). Uses \`response_format: json_object\` for reliable structured output. Replace \`ANTHROPIC_API_KEY\` with \`OPENAI_API_KEY\` in Vercel env vars.
- **New pages** — \`/alerts\`, \`/bookmarks\`, \`/history\`, \`/settings\` all wired up with mock support and real API fallback.
- **Vitest suite** — 73 tests across 5 files: \`matchesHardFilters\` edge cases, mock data shape invariants, bookmark add/remove/sold logic, sold detection simulation, cookie prefs round-trip, default type values.

## Test plan

- [ ] \`pnpm test\` — 73 tests pass
- [ ] \`pnpm build\` — clean TypeScript, no errors
- [ ] Star a listing in mock mode → toast appears, bookmark persists to \`/bookmarks\`
- [ ] Verify mock toggle is hidden in production build (no \`NEXT_PUBLIC_ENABLE_MOCK\` set)
- [ ] Add \`OPENAI_API_KEY\` to Vercel env vars, remove \`ANTHROPIC_API_KEY\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)